### PR TITLE
feat(security): Brute-Force-Schutz und Security Headers

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -31,6 +31,19 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 if not DEBUG:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+    # Security Headers
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_HSTS_SECONDS = 31536000  # 1 Jahr
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    X_FRAME_OPTIONS = "DENY"
+    SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+    # Cookie-Sicherheit
+    SESSION_COOKIE_HTTPONLY = True
+    CSRF_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    CSRF_COOKIE_SAMESITE = "Lax"
 
 # ---------------------------------------------------------------------------
 # Application definition
@@ -200,6 +213,8 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/hour",
         "user": "1000/hour",
+        "login": "5/minute",
+        "password_reset": "3/hour",
     },
     "DATETIME_FORMAT": "%Y-%m-%dT%H:%M:%S%z",
     "DATE_FORMAT": "%Y-%m-%d",

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -6,10 +6,19 @@ and authenticated API clients.
 """
 
 import pytest
+from django.core.cache import cache
 from django.test import override_settings
 from rest_framework.test import APIClient
 
 from core.models import Location, Organization, User
+
+
+@pytest.fixture(autouse=True)
+def clear_throttle_cache():
+    """Clear the throttle cache before each test to prevent 429 responses."""
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -8,6 +8,7 @@ and user profile management.
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import permissions, status
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenRefreshView
 
@@ -28,9 +29,12 @@ class LoginView(APIView):
 
     Authenticate a user with username/email and password.
     Returns JWT access and refresh tokens along with user data.
+    Rate limited to 5 attempts per minute to prevent brute-force attacks.
     """
 
     permission_classes = [permissions.AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "login"
     serializer_class = LoginSerializer
 
     @extend_schema(
@@ -138,9 +142,12 @@ class PasswordResetRequestView(APIView):
 
     Request a password reset email.
     Always returns 200 to prevent email enumeration.
+    Rate limited to 3 requests per hour to prevent abuse.
     """
 
     permission_classes = [permissions.AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "password_reset"
     serializer_class = PasswordResetRequestSerializer
 
     @extend_schema(


### PR DESCRIPTION
## Security Headers (Produktion)
- HSTS: 1 Jahr, inkl. Subdomains, Preload
- X-Frame-Options: DENY
- X-Content-Type-Options: nosniff
- Referrer-Policy: strict-origin-when-cross-origin
- XSS-Filter aktiviert

## Cookie-Sicherheit
- HttpOnly für Session und CSRF Cookies
- SameSite=Lax

## Brute-Force-Schutz
- Login: max. 5 Versuche/Minute (ScopedRateThrottle)
- Password-Reset: max. 3 Anfragen/Stunde

Closes #12
Closes #13