### PR TITLE
fix: resolve production login redirect loop (Sprint 20)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-/**
- * Root page – redirects to the login page.
- * Authenticated users will be redirected to the dashboard by middleware.
- */
-export default function RootPage() {
-  redirect("/login");
-}

--- a/frontend/src/components/auth-provider.tsx
+++ b/frontend/src/components/auth-provider.tsx
@@ -26,13 +26,18 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 /**
  * Set a simple cookie to signal authentication status to the middleware.
+ *
+ * Uses Secure flag on HTTPS to ensure the cookie is sent with server requests.
+ * Uses SameSite=Lax for CSRF protection while allowing normal navigation.
  */
 function setAuthCookie(authenticated: boolean) {
   if (typeof document === "undefined") return;
+  const isSecure = window.location.protocol === "https:";
+  const secureFlag = isSecure ? "; Secure" : "";
   if (authenticated) {
-    document.cookie = "is_authenticated=true; path=/; max-age=604800; SameSite=Lax";
+    document.cookie = `is_authenticated=true; path=/; max-age=604800; SameSite=Lax${secureFlag}`;
   } else {
-    document.cookie = "is_authenticated=; path=/; max-age=0; SameSite=Lax";
+    document.cookie = `is_authenticated=; path=/; max-age=0; SameSite=Lax${secureFlag}`;
   }
 }
 
@@ -92,12 +97,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Fetch full profile after login
         const profile = await authApi.getProfile();
         setUser(profile);
-        router.push("/");
+
+        // Use window.location for a full page navigation to ensure
+        // the middleware sees the newly set cookie on the server request.
+        // router.push() uses client-side navigation which may not trigger
+        // a fresh server request with the updated cookies.
+        window.location.href = "/";
       }
 
       return response;
     },
-    [router],
+    [],
   );
 
   /**
@@ -115,10 +125,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Fetch full profile after login
         const profile = await authApi.getProfile();
         setUser(profile);
-        router.push("/");
+
+        // Use window.location for a full page navigation (see login above)
+        window.location.href = "/";
       }
     },
-    [router],
+    [],
   );
 
   /**

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -8,19 +8,33 @@ import type { NextRequest } from "next/server";
  * we use a lightweight cookie-based flag to check auth status in middleware.
  * The actual token validation happens on the client side via the AuthProvider.
  *
- * Public routes: /login, /forgot-password, /api/*
+ * Public routes: /login, /forgot-password, /reset-password, /api/*
  * Protected routes: everything else (dashboard, etc.)
+ *
+ * IMPORTANT: All middleware responses set Cache-Control: no-store to prevent
+ * CDN/edge caching of authentication-dependent redirects.
  */
 
 const PUBLIC_PATHS = ["/login", "/forgot-password", "/reset-password"];
 
+/**
+ * Apply no-cache headers to prevent CDN/edge caching of auth-dependent responses.
+ */
+function withNoCacheHeaders(response: NextResponse): NextResponse {
+  response.headers.set(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, proxy-revalidate",
+  );
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Expires", "0");
+  return response;
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Allow public paths and API routes
+  // Allow static assets and Next.js internals without modification
   if (
-    PUBLIC_PATHS.some((path) => pathname.startsWith(path)) ||
-    pathname.startsWith("/api") ||
     pathname.startsWith("/_next") ||
     pathname.startsWith("/assets") ||
     pathname.startsWith("/icons") ||
@@ -33,13 +47,29 @@ export function middleware(request: NextRequest) {
   // Check for auth cookie (set by client after login)
   const isAuthenticated = request.cookies.get("is_authenticated");
 
+  // Public paths: allow access, but redirect authenticated users away from login
+  if (
+    PUBLIC_PATHS.some((path) => pathname.startsWith(path)) ||
+    pathname.startsWith("/api")
+  ) {
+    // If user is already authenticated and tries to access /login, redirect to dashboard
+    if (isAuthenticated && pathname.startsWith("/login")) {
+      const dashboardUrl = new URL("/", request.url);
+      return withNoCacheHeaders(NextResponse.redirect(dashboardUrl));
+    }
+
+    return withNoCacheHeaders(NextResponse.next());
+  }
+
+  // Protected routes: redirect to login if not authenticated
   if (!isAuthenticated) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(loginUrl);
+    return withNoCacheHeaders(NextResponse.redirect(loginUrl));
   }
 
-  return NextResponse.next();
+  // Authenticated user accessing protected route – allow access
+  return withNoCacheHeaders(NextResponse.next());
 }
 
 export const config = {


### PR DESCRIPTION
## Sprint 20 - CRITICAL: Fix Production Login Redirect Loop

### Problem
Users could not login on **www.gtsplaner.app**. After entering valid credentials, the login form cleared but users remained on the login page instead of being redirected to the dashboard. This affected all 4 test user roles.

### Root Cause Analysis

Four interconnected issues were identified:

| Issue | Description | Impact |
|-------|-------------|--------|
| Server-side redirect | `app/page.tsx` always redirected to `/login`, preventing dashboard from rendering on `/` | Dashboard never accessible |
| CDN caching | 307 redirect cached with `s-maxage=31536000` (1 year) | Even valid cookies ignored |
| Missing Secure flag | Auth cookie lacked `Secure` flag on HTTPS | Cookie not sent to server |
| Client-side navigation | `router.push()` didn't trigger fresh server request | Middleware didn't see new cookie |

### Changes

**`frontend/src/app/page.tsx`** - DELETED
- Removed the root page that always redirected to `/login`
- `(dashboard)/page.tsx` now correctly renders on `/` via route group

**`frontend/src/middleware.ts`** - UPDATED
- Added `Cache-Control: no-store` headers to ALL middleware responses
- Added redirect from `/login` to `/` for already-authenticated users
- Restructured middleware logic for clarity

**`frontend/src/components/auth-provider.tsx`** - UPDATED
- Added `Secure` flag to auth cookie when on HTTPS
- Changed `router.push("/")` to `window.location.href = "/"` for full page navigation
- Ensures middleware sees the newly set cookie on server request

### Testing
- Build passes successfully
- All routes correctly listed in build output
- `/` route now maps to dashboard (was previously missing from route list)
