### PR TITLE
fix: Clear stale tokens before login to prevent token type error

### DIFF
--- a/frontend/src/components/auth-provider.tsx
+++ b/frontend/src/components/auth-provider.tsx
@@ -81,6 +81,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    */
   const login = useCallback(
     async (credentials: LoginCredentials): Promise<LoginResponse> => {
+      // Clear any stale tokens before attempting login to prevent
+      // the request interceptor from attaching an expired token
+      // that could interfere with the login flow.
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+
       const response = await authApi.login(credentials);
 
       // If 2FA is required, don't store tokens yet – return response for 2FA page


### PR DESCRIPTION
## Problem
Wenn ein Benutzer abgelaufene Tokens im localStorage von einer vorherigen Session hat, schlägt der Login-Flow mit der Fehlermeldung **"Der Token ist für keinen Tokentyp gültig"** fehl.

## Root Cause
Der Request-Interceptor hängt den abgelaufenen Token an den Login-Request an. Der Response-Interceptor versucht dann, den Token zu refreshen, was fehlschlägt und die Fehlermeldung im Login-Formular anzeigt.

## Fix
Alte Tokens werden aus dem localStorage gelöscht, **bevor** der Login-API-Call gemacht wird. Dies stellt einen sauberen Authentifizierungsfluss sicher.

## Getestet
- Login als Location Manager (locationmanager@gtsplaner.app) auf www.gtsplaner.app ✅
- Login nach vorheriger Session mit abgelaufenen Tokens ✅
- Dashboard zeigt korrekte Daten nach Login ✅

Closes #60