### PR TITLE
feat: Sprint 24 - Educator-Rolle Berechtigungen und Route-Guards

### DIFF
--- a/backend/core/management/commands/create_test_users.py
+++ b/backend/core/management/commands/create_test_users.py
@@ -11,6 +11,7 @@ Usage:
 from django.core.management.base import BaseCommand
 
 from core.models import Location, Organization, User
+from groups.models import Group, GroupMember
 
 
 class Command(BaseCommand):
@@ -113,8 +114,45 @@ class Command(BaseCommand):
         self.stdout.write("=" * 70)
         self.stdout.write(
             self.style.SUCCESS(
-                f"\n✓ {len(self.TEST_USERS)} Test-Benutzer erstellt/aktualisiert."
+                f"\n\u2713 {len(self.TEST_USERS)} Test-Benutzer erstellt/aktualisiert."
             )
         )
         self.stdout.write(f"  Organisation: {org.name}")
-        self.stdout.write(f"  Standort:     {location.name}\n")
+        self.stdout.write(f"  Standort:     {location.name}")
+
+        # Assign educator to existing groups as group member
+        self._assign_educator_to_groups(location)
+
+        self.stdout.write("")
+
+    def _assign_educator_to_groups(self, location: Location) -> None:
+        """Assign the educator test user to all groups at the location."""
+        try:
+            educator = User.objects.get(username="educator")
+        except User.DoesNotExist:
+            return
+
+        groups = Group.objects.filter(location=location, is_active=True)
+        if not groups.exists():
+            self.stdout.write(
+                self.style.WARNING(
+                    "  Keine Gruppen gefunden. Bitte zuerst Gruppen anlegen "
+                    "und dann erneut ausfuehren."
+                )
+            )
+            return
+
+        assigned_count = 0
+        for group in groups:
+            _, created = GroupMember.objects.get_or_create(
+                group=group,
+                user=educator,
+                defaults={"role": GroupMember.MemberRole.EDUCATOR},
+            )
+            if created:
+                assigned_count += 1
+
+        self.stdout.write(
+            f"  Gruppenmitgliedschaften (Educator): {assigned_count} neu, "
+            f"{groups.count() - assigned_count} bereits vorhanden"
+        )

--- a/frontend/src/app/(dashboard)/finance/categories/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/categories/page.tsx
@@ -48,9 +48,11 @@ import {
   Pencil,
   Trash2,
 } from "lucide-react";
+import { usePermissions } from "@/hooks/use-permissions";
 
 export default function CategoriesPage() {
   const toast = useToast();
+  const { canCreate } = usePermissions();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [search, setSearch] = useState("");
@@ -138,10 +140,12 @@ export default function CategoriesPage() {
         title="Kategorien"
         description="Verwalte Einnahme- und Ausgabe-Kategorien."
       >
-        <Button onClick={handleCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          Neue Kategorie
-        </Button>
+        {canCreate("category") && (
+          <Button onClick={handleCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            Neue Kategorie
+          </Button>
+        )}
       </PageHeader>
 
       {/* Search */}
@@ -250,8 +254,8 @@ export default function CategoriesPage() {
               ? "Keine Kategorien für diese Suche gefunden."
               : "Es wurden noch keine Kategorien angelegt."
           }
-          actionLabel="Neue Kategorie"
-          onAction={handleCreate}
+          actionLabel={canCreate("category") ? "Neue Kategorie" : undefined}
+          onAction={canCreate("category") ? handleCreate : undefined}
         />
       )}
 

--- a/frontend/src/app/(dashboard)/groups/list/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/list/page.tsx
@@ -50,9 +50,11 @@ import {
   Trash2,
   Search,
 } from "lucide-react";
+import { usePermissions } from "@/hooks/use-permissions";
 
 export default function GroupsListPage() {
   const toast = useToast();
+  const { canCreate } = usePermissions();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [search, setSearch] = useState("");
@@ -145,10 +147,12 @@ export default function GroupsListPage() {
         title="Gruppen"
         description="Verwalte alle Gruppen und deren Mitglieder."
       >
-        <Button onClick={handleCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          Neue Gruppe
-        </Button>
+        {canCreate("group") && (
+          <Button onClick={handleCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            Neue Gruppe
+          </Button>
+        )}
       </PageHeader>
 
       {/* Search */}
@@ -238,23 +242,27 @@ export default function GroupsListPage() {
                               Details
                             </Link>
                           </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => handleEdit(group)}
-                          >
-                            <Pencil className="mr-2 h-4 w-4" />
-                            Bearbeiten
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setDeleteId(group.id);
-                              setDeleteDialogOpen(true);
-                            }}
-                            className="text-destructive"
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            Löschen
-                          </DropdownMenuItem>
+                          {canCreate("group") && (
+                            <>
+                              <DropdownMenuItem
+                                onClick={() => handleEdit(group)}
+                              >
+                                <Pencil className="mr-2 h-4 w-4" />
+                                Bearbeiten
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  setDeleteId(group.id);
+                                  setDeleteDialogOpen(true);
+                                }}
+                                className="text-destructive"
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                Löschen
+                              </DropdownMenuItem>
+                            </>
+                          )}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </TableCell>
@@ -284,8 +292,8 @@ export default function GroupsListPage() {
               ? "Keine Gruppen für diese Suche gefunden."
               : "Es wurden noch keine Gruppen angelegt."
           }
-          actionLabel="Neue Gruppe"
-          onAction={handleCreate}
+          actionLabel={canCreate("group") ? "Neue Gruppe" : undefined}
+          onAction={canCreate("group") ? handleCreate : undefined}
         />
       )}
 

--- a/frontend/src/app/(dashboard)/groups/students/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/students/page.tsx
@@ -48,9 +48,11 @@ import {
   Trash2,
   Search,
 } from "lucide-react";
+import { usePermissions } from "@/hooks/use-permissions";
 
 export default function StudentsPage() {
   const toast = useToast();
+  const { canCreate } = usePermissions();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [search, setSearch] = useState("");
@@ -143,10 +145,12 @@ export default function StudentsPage() {
         title="Kinder"
         description="Verwalte alle Kinder und deren Gruppenzuordnung."
       >
-        <Button onClick={handleCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          Neues Kind
-        </Button>
+        {canCreate("student") && (
+          <Button onClick={handleCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            Neues Kind
+          </Button>
+        )}
       </PageHeader>
 
       {/* Search */}
@@ -265,8 +269,8 @@ export default function StudentsPage() {
               ? "Keine Kinder für diese Suche gefunden."
               : "Es wurden noch keine Kinder erfasst."
           }
-          actionLabel="Neues Kind"
-          onAction={handleCreate}
+          actionLabel={canCreate("student") ? "Neues Kind" : undefined}
+          onAction={canCreate("student") ? handleCreate : undefined}
         />
       )}
 

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { ProtectedRoute } from "@/components/protected-route";
+import { RouteGuard } from "@/components/route-guard";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -37,7 +38,9 @@ export default function DashboardLayout({
                 sidebarCollapsed={sidebarCollapsed}
                 onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
               />
-              <main className="flex-1 p-4 sm:p-6">{children}</main>
+              <main className="flex-1 p-4 sm:p-6">
+                <RouteGuard>{children}</RouteGuard>
+              </main>
             </div>
           </div>
 

--- a/frontend/src/app/(dashboard)/page.tsx
+++ b/frontend/src/app/(dashboard)/page.tsx
@@ -150,16 +150,16 @@ export default function DashboardPage() {
           icon={Wallet}
           loading={loadingTx}
         />
-        <StatCard
-          title="Ausstehende Genehmigungen"
-          value={String(pendingTx?.count ?? 0)}
-          description={
-            isManager ? "Warten auf deine Freigabe" : "Warten auf Freigabe"
-          }
-          icon={AlertCircle}
-          trend={pendingTx?.count ? "up" : "neutral"}
-          loading={loadingPending}
-        />
+        {isManager && (
+          <StatCard
+            title="Ausstehende Genehmigungen"
+            value={String(pendingTx?.count ?? 0)}
+            description="Warten auf deine Freigabe"
+            icon={AlertCircle}
+            trend={pendingTx?.count ? "up" : "neutral"}
+            loading={loadingPending}
+          />
+        )}
         <StatCard
           title="Zeiteinträge"
           value={String(timeEntries?.count ?? 0)}

--- a/frontend/src/components/route-guard.tsx
+++ b/frontend/src/components/route-guard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/hooks/use-auth";
+import { getRequiredRoleForPath } from "@/hooks/use-permissions";
+import type { UserRole } from "@/types/models";
+import { ShieldOff, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+const roleHierarchy: Record<UserRole, number> = {
+  educator: 1,
+  location_manager: 2,
+  admin: 3,
+  super_admin: 4,
+};
+
+/**
+ * Route guard component that checks if the current user has
+ * permission to access the current page based on the route
+ * permission configuration.
+ *
+ * Renders a "Zugriff verweigert" page if the user lacks
+ * the required role. Otherwise, renders children normally.
+ */
+export function RouteGuard({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { user } = useAuth();
+
+  if (!user) return <>{children}</>;
+
+  const requiredRole = getRequiredRoleForPath(pathname);
+
+  if (requiredRole && roleHierarchy[user.role] < roleHierarchy[requiredRole]) {
+    return (
+      <Card className="mx-auto mt-8 max-w-lg">
+        <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+          <ShieldOff className="h-12 w-12 text-orange-500" />
+          <div>
+            <h3 className="text-lg font-semibold">Zugriff verweigert</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Sie haben nicht die erforderliche Berechtigung, um auf diesen
+              Bereich zuzugreifen. Bitte wenden Sie sich an Ihren Administrator.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => window.history.back()}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Zurück
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/hooks/use-permissions.ts
+++ b/frontend/src/hooks/use-permissions.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useAuth } from "@/hooks/use-auth";
+import type { UserRole } from "@/types/models";
+
+/**
+ * Role hierarchy for permission checks.
+ * Higher number = more permissions.
+ */
+const roleHierarchy: Record<UserRole, number> = {
+  educator: 1,
+  location_manager: 2,
+  admin: 3,
+  super_admin: 4,
+};
+
+/**
+ * Route permission configuration.
+ * Maps URL path prefixes to the minimum required role.
+ * Order matters: more specific paths should come first.
+ */
+const routePermissions: { path: string; minRole: UserRole }[] = [
+  // Admin routes (already protected via API 403, but adding frontend guard too)
+  { path: "/admin/organizations", minRole: "super_admin" },
+  { path: "/admin/users", minRole: "admin" },
+  { path: "/admin/audit-log", minRole: "admin" },
+  { path: "/admin/settings", minRole: "admin" },
+
+  // Finance routes restricted to location_manager+
+  { path: "/finance/reports", minRole: "location_manager" },
+  { path: "/finance/categories", minRole: "location_manager" },
+
+  // Group management routes restricted to location_manager+
+  { path: "/groups/students", minRole: "location_manager" },
+  { path: "/groups/new", minRole: "location_manager" },
+
+  // Timetracking approval restricted to location_manager+
+  { path: "/timetracking/approval", minRole: "location_manager" },
+];
+
+/**
+ * Resource-level create permissions.
+ * Defines which roles can create specific resources.
+ */
+const createPermissions: Record<string, UserRole[]> = {
+  group: ["location_manager", "admin", "super_admin"],
+  category: ["location_manager", "admin", "super_admin"],
+  student: ["location_manager", "admin", "super_admin"],
+  transaction: ["educator", "location_manager", "admin", "super_admin"],
+  time_entry: ["educator", "location_manager", "admin", "super_admin"],
+  leave_request: ["educator", "location_manager", "admin", "super_admin"],
+};
+
+/**
+ * Check if a user role meets the minimum required role.
+ */
+function hasMinRole(userRole: UserRole, minRole: UserRole): boolean {
+  return roleHierarchy[userRole] >= roleHierarchy[minRole];
+}
+
+/**
+ * Get the minimum required role for a given pathname.
+ * Returns null if no restriction is configured (open to all authenticated users).
+ */
+export function getRequiredRoleForPath(pathname: string): UserRole | null {
+  for (const { path, minRole } of routePermissions) {
+    if (pathname === path || pathname.startsWith(path + "/")) {
+      return minRole;
+    }
+  }
+  return null;
+}
+
+/**
+ * Hook for permission checks throughout the application.
+ *
+ * Provides:
+ * - `canAccessRoute(path)`: Check if user can access a specific route
+ * - `canCreate(resource)`: Check if user can create a specific resource
+ * - `hasRole(minRole)`: Check if user meets minimum role requirement
+ * - `isAtLeast(role)`: Alias for hasRole
+ */
+export function usePermissions() {
+  const { user } = useAuth();
+
+  const canAccessRoute = (pathname: string): boolean => {
+    if (!user) return false;
+    const requiredRole = getRequiredRoleForPath(pathname);
+    if (!requiredRole) return true;
+    return hasMinRole(user.role, requiredRole);
+  };
+
+  const canCreate = (resource: string): boolean => {
+    if (!user) return false;
+    const allowedRoles = createPermissions[resource];
+    if (!allowedRoles) return false;
+    return allowedRoles.includes(user.role);
+  };
+
+  const hasRole = (minRole: UserRole): boolean => {
+    if (!user) return false;
+    return hasMinRole(user.role, minRole);
+  };
+
+  return {
+    canAccessRoute,
+    canCreate,
+    hasRole,
+    isAtLeast: hasRole,
+    user,
+  };
+}


### PR DESCRIPTION
## Sprint 24 - Educator-Rolle Berechtigungen

### Geloeste Issues
- **#77**: Zentrale Route-Guard-Middleware (loest auch #67, #72)
- **#78**: Rollenbasierte Button-Sichtbarkeit (loest auch #73, #74, #75)
- **#76**: Dashboard Genehmigungen-Card fuer Educator ausblenden
- **#70**: Seed Data: Educator als Gruppenmitglied (loest auch #68, #71)

### Aenderungen

#### Neue Dateien
- `frontend/src/hooks/use-permissions.ts`: Zentraler usePermissions Hook
- `frontend/src/components/route-guard.tsx`: RouteGuard Komponente

#### Frontend-Aenderungen
- **Dashboard-Layout**: RouteGuard um children gewrapped
- **Dashboard-Seite**: Genehmigungen-Card nur fuer isManager sichtbar
- **Gruppen-Liste**: Neue Gruppe, Bearbeiten, Loeschen Buttons nur fuer location_manager+
- **Kategorien-Seite**: Neue Kategorie Button nur fuer location_manager+
- **Schueler-Seite**: Neues Kind Button nur fuer location_manager+

#### Backend-Aenderungen
- **create_test_users**: Weist Educator automatisch als GroupMember allen aktiven Gruppen zu

### Geschuetzte Routen (Route-Guard)

| Route | Min. Rolle |
|-------|-----------|
| /finance/reports | location_manager |
| /finance/categories | location_manager |
| /groups/students | location_manager |
| /groups/new | location_manager |
| /timetracking/approval | location_manager |
| /admin/users | admin |
| /admin/audit-log | admin |
| /admin/settings | admin |
| /admin/organizations | super_admin |

### Testanleitung
1. Login als educator@gtsplaner.app / Test123!
2. Pruefen: Keine Neue Gruppe/Kategorie/Kind Buttons sichtbar
3. Pruefen: Direkte URL-Eingabe von /finance/reports zeigt Zugriff verweigert
4. Pruefen: Dashboard zeigt keine Genehmigungen-Card
5. python manage.py create_test_users ausfuehren - Educator wird Gruppenmitglied
6. Gruppen-Dropdown in Transaktions-Form zeigt jetzt Gruppen

Closes #67, #68, #70, #71, #72, #73, #74, #75, #76, #77, #78
