### PR TITLE
Sprint 39: OpenAPI Fixes, WeeklyPlan Tests & Features

### DIFF
--- a/backend/admin_panel/views.py
+++ b/backend/admin_panel/views.py
@@ -129,6 +129,9 @@ class SystemSettingViewSet(viewsets.ModelViewSet):
     ordering = ["key"]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return SystemSetting.objects.none()
+
         user = self.request.user
         if user.role in ["admin", "super_admin"]:
             return SystemSetting.objects.all()

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -269,13 +269,13 @@ SIMPLE_JWT = {
 # ---------------------------------------------------------------------------
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "Kassenbuch App v2 API",
+    "TITLE": "GTS Planer API",
     "DESCRIPTION": (
-        "REST API für die Kassenbuch App v2 – "
-        "Verwaltung von Klassenkassen für Freizeitpädagoginnen. "
+        "REST API für den GTS Planer – "
+        "Verwaltung von Ganztagsschul-Gruppen, Wochenplänen, Finanzen und Zeiterfassung. "
         "Django + Next.js Headless Architecture."
     ),
-    "VERSION": "2.0.0",
+    "VERSION": "2.4.0",
     "SERVE_INCLUDE_SCHEMA": False,
     "COMPONENT_SPLIT_REQUEST": True,
     "SCHEMA_PATH_PREFIX": r"/api/v1",
@@ -285,9 +285,22 @@ SPECTACULAR_SETTINGS = {
         {"name": "Finance", "description": "Kassenbuch & Transaktionen"},
         {"name": "TimeTracking", "description": "Zeiterfassung & Arbeitszeiten"},
         {"name": "Groups", "description": "Gruppen- & Schülerverwaltung"},
+        {"name": "WeeklyPlans", "description": "Wochenpläne & Tagesaktivitäten"},
         {"name": "Admin", "description": "Admin-Funktionen & Systemverwaltung"},
         {"name": "System", "description": "Systemeinstellungen & Audit-Log"},
     ],
+    "ENUM_NAME_OVERRIDES": {
+        # Resolve enum naming collisions for 'status' fields across models
+        "WeeklyPlanStatusEnum": "weeklyplans.models.WeeklyPlan.STATUS_CHOICES",
+        "TransactionStatusEnum": "finance.models.Transaction.Status",
+        "LeaveRequestStatusEnum": "timetracking.models.LeaveRequest.Status",
+        "AttendanceStatusEnum": "groups.models_attendance.Attendance.Status",
+        # Resolve enum naming collisions for 'role' fields
+        "UserRoleEnum": "core.models.User.Role",
+        "GroupMemberRoleEnum": "groups.models.GroupMember.MemberRole",
+        # Resolve TransactionType duplicate naming
+        "TransactionTypeEnum": "finance.models.Transaction.TransactionType",
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/backend/core/views_locations.py
+++ b/backend/core/views_locations.py
@@ -61,18 +61,18 @@ class LocationGroupCompactSerializer(serializers.Serializer):
     member_count = serializers.SerializerMethodField()
     is_active = serializers.BooleanField(read_only=True)
 
-    def get_leader_name(self, obj):
+    def get_leader_name(self, obj) -> str | None:
         if obj.leader:
             return f"{obj.leader.first_name} {obj.leader.last_name}"
         return None
 
-    def get_leader_id(self, obj):
+    def get_leader_id(self, obj) -> int | None:
         return obj.leader_id
 
-    def get_student_count(self, obj):
+    def get_student_count(self, obj) -> int:
         return obj.students.filter(is_deleted=False).count()
 
-    def get_member_count(self, obj):
+    def get_member_count(self, obj) -> int:
         return obj.members.filter(is_active=True).count()
 
 
@@ -111,15 +111,15 @@ class LocationListSerializer(serializers.ModelSerializer):
             "educator_count",
         ]
 
-    def get_group_count(self, obj):
+    def get_group_count(self, obj) -> int:
         return Group.objects.filter(location=obj, is_active=True).count()
 
-    def get_student_count(self, obj):
+    def get_student_count(self, obj) -> int:
         return Student.objects.filter(
             group__location=obj, is_deleted=False
         ).count()
 
-    def get_educator_count(self, obj):
+    def get_educator_count(self, obj) -> int:
         return User.objects.filter(
             location=obj, is_deleted=False, is_active=True
         ).exclude(role=User.Role.LOCATION_MANAGER).count()
@@ -169,21 +169,21 @@ class LocationDetailSerializer(serializers.ModelSerializer):
             "educator_count",
         ]
 
-    def get_groups(self, obj):
+    def get_groups(self, obj) -> list:
         groups = Group.objects.filter(
             location=obj, is_active=True
         ).select_related("leader")
         return LocationGroupCompactSerializer(groups, many=True).data
 
-    def get_group_count(self, obj):
+    def get_group_count(self, obj) -> int:
         return Group.objects.filter(location=obj, is_active=True).count()
 
-    def get_student_count(self, obj):
+    def get_student_count(self, obj) -> int:
         return Student.objects.filter(
             group__location=obj, is_deleted=False
         ).count()
 
-    def get_educator_count(self, obj):
+    def get_educator_count(self, obj) -> int:
         return User.objects.filter(
             location=obj, is_deleted=False, is_active=True
         ).exclude(role=User.Role.LOCATION_MANAGER).count()

--- a/backend/core/views_users.py
+++ b/backend/core/views_users.py
@@ -67,6 +67,9 @@ class UserViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated, IsAdminOrAbove]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return User.objects.none()
+
         # Ensure tenant context is resolved (lazy resolution for JWT auth)
         ensure_tenant_context(self.request)
 

--- a/backend/finance/serializers/finance_serializers.py
+++ b/backend/finance/serializers/finance_serializers.py
@@ -14,7 +14,7 @@ from finance.models import Receipt, Transaction, TransactionCategory
 # Nested / Compact Serializers (for embedding in other responses)
 # ---------------------------------------------------------------------------
 
-class UserCompactSerializer(serializers.Serializer):
+class FinanceUserCompactSerializer(serializers.Serializer):
     """Compact user representation for nested display."""
 
     id = serializers.IntegerField(read_only=True)
@@ -93,7 +93,7 @@ class TransactionCategoryCreateSerializer(serializers.ModelSerializer):
 class ReceiptSerializer(serializers.ModelSerializer):
     """Serializer for receipt display."""
 
-    uploaded_by = UserCompactSerializer(read_only=True)
+    uploaded_by = FinanceUserCompactSerializer(read_only=True)
     file_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -143,8 +143,8 @@ class TransactionListSerializer(serializers.ModelSerializer):
     category_name = serializers.CharField(
         source="category.name", read_only=True, default=None
     )
-    created_by = UserCompactSerializer(read_only=True)
-    approved_by = UserCompactSerializer(read_only=True)
+    created_by = FinanceUserCompactSerializer(read_only=True)
+    approved_by = FinanceUserCompactSerializer(read_only=True)
     receipt_count = serializers.IntegerField(
         source="receipts.count", read_only=True
     )
@@ -186,8 +186,8 @@ class TransactionDetailSerializer(serializers.ModelSerializer):
     category_name = serializers.CharField(
         source="category.name", read_only=True, default=None
     )
-    created_by = UserCompactSerializer(read_only=True)
-    approved_by = UserCompactSerializer(read_only=True)
+    created_by = FinanceUserCompactSerializer(read_only=True)
+    approved_by = FinanceUserCompactSerializer(read_only=True)
     receipts = ReceiptSerializer(many=True, read_only=True)
 
     class Meta:

--- a/backend/groups/serializers/groups_serializers.py
+++ b/backend/groups/serializers/groups_serializers.py
@@ -12,8 +12,8 @@ from groups.models import Group, GroupMember, SchoolYear, Semester, Student
 # Nested / Compact Serializers
 # ---------------------------------------------------------------------------
 
-class UserCompactSerializer(serializers.Serializer):
-    """Compact user representation for nested display."""
+class GroupUserCompactSerializer(serializers.Serializer):
+    """Compact user representation for nested display in groups."""
 
     id = serializers.IntegerField(read_only=True)
     first_name = serializers.CharField(read_only=True)
@@ -236,7 +236,7 @@ class GroupListSerializer(serializers.ModelSerializer):
 
     location_name = serializers.CharField(source="location.name", read_only=True)
     school_year_name = serializers.CharField(source="school_year.name", read_only=True)
-    leader = UserCompactSerializer(read_only=True)
+    leader = GroupUserCompactSerializer(read_only=True)
     member_count = serializers.IntegerField(source="members.count", read_only=True)
     student_count = serializers.IntegerField(source="students.count", read_only=True)
 
@@ -266,7 +266,7 @@ class GroupDetailSerializer(serializers.ModelSerializer):
 
     location_name = serializers.CharField(source="location.name", read_only=True)
     school_year_name = serializers.CharField(source="school_year.name", read_only=True)
-    leader = UserCompactSerializer(read_only=True)
+    leader = GroupUserCompactSerializer(read_only=True)
     members = GroupMemberSerializer(many=True, read_only=True)
     students = StudentListSerializer(many=True, read_only=True)
 

--- a/backend/groups/serializers_attendance.py
+++ b/backend/groups/serializers_attendance.py
@@ -45,12 +45,12 @@ class AttendanceSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
-    def get_student_name(self, obj):
+    def get_student_name(self, obj) -> str:
         if obj.student:
             return f"{obj.student.first_name or ''} {obj.student.last_name or ''}".strip()
         return ""
 
-    def get_recorded_by_name(self, obj):
+    def get_recorded_by_name(self, obj) -> str | None:
         if obj.recorded_by:
             return f"{obj.recorded_by.first_name} {obj.recorded_by.last_name}".strip()
         return None

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 info:
-  title: Kassenbuch App v2 API
-  version: 2.0.0
-  description: REST API für die Kassenbuch App v2 – Verwaltung von Klassenkassen für
-    Freizeitpädagoginnen. Django + Next.js Headless Architecture.
+  title: GTS Planer API
+  version: 2.4.0
+  description: REST API für den GTS Planer – Verwaltung von Ganztagsschul-Gruppen,
+    Wochenplänen, Finanzen und Zeiterfassung. Django + Next.js Headless Architecture.
 paths:
   /api/health/:
     get:
@@ -541,7 +541,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Systemeinstellung identifiziert.
         required: true
       tags:
       - Admin
@@ -564,7 +565,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Systemeinstellung identifiziert.
         required: true
       tags:
       - Admin
@@ -599,7 +601,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Systemeinstellung identifiziert.
         required: true
       tags:
       - Admin
@@ -633,7 +636,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Systemeinstellung identifiziert.
         required: true
       tags:
       - Admin
@@ -4537,6 +4541,14 @@ paths:
         - Other roles: no access (empty queryset)
       summary: Benutzer auflisten
       parameters:
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
+      - in: query
+        name: location_id
+        schema:
+          type: number
       - name: ordering
         required: false
         in: query
@@ -4549,6 +4561,21 @@ paths:
         description: Eine Seitenzahl in der paginierten Ergebnismenge.
         schema:
           type: integer
+      - in: query
+        name: role
+        schema:
+          type: string
+          title: Rolle
+          enum:
+          - admin
+          - educator
+          - location_manager
+          - super_admin
+        description: |-
+          * `educator` - Pädagogin
+          * `location_manager` - Standortleitung
+          * `admin` - Admin
+          * `super_admin` - Super Admin
       - name: search
         required: false
         in: query
@@ -4618,7 +4645,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Benutzer identifiziert.
         required: true
       tags:
       - Users
@@ -4647,7 +4675,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Benutzer identifiziert.
         required: true
       tags:
       - Users
@@ -4687,7 +4716,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Benutzer identifiziert.
         required: true
       tags:
       - Users
@@ -4727,7 +4757,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Benutzer identifiziert.
         required: true
       tags:
       - Users
@@ -5158,7 +5189,7 @@ components:
           format: date
           title: Datum
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -5172,6 +5203,7 @@ components:
           title: Erfasst von
         recorded_by_name:
           type: string
+          nullable: true
           readOnly: true
         student_name:
           type: string
@@ -5210,7 +5242,7 @@ components:
           format: date
           title: Datum
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           title: Notizen
@@ -5233,7 +5265,7 @@ components:
           format: date
           title: Datum
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           title: Notizen
@@ -5256,7 +5288,7 @@ components:
           format: date
           title: Datum
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           title: Notizen
@@ -5264,6 +5296,18 @@ components:
       - date
       - group
       - student
+    AttendanceStatusEnum:
+      enum:
+      - present
+      - absent
+      - sick
+      - excused
+      type: string
+      description: |-
+        * `present` - Anwesend
+        * `absent` - Abwesend
+        * `sick` - Krank
+        * `excused` - Beurlaubt
     AuditLog:
       type: object
       description: Serializer for audit log entries.
@@ -5335,7 +5379,7 @@ components:
         student_id:
           type: integer
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           default: ''
@@ -5349,7 +5393,7 @@ components:
         student_id:
           type: integer
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           default: ''
@@ -5398,14 +5442,6 @@ components:
         * `sozial` - Soziales Lernen
         * `ruhe` - Ruhezeit
         * `sonstiges` - Sonstiges
-    CategoryTypeEnum:
-      enum:
-      - income
-      - expense
-      type: string
-      description: |-
-        * `income` - Einnahme
-        * `expense` - Ausgabe
     DailyActivity:
       type: object
       description: Serializer for daily activity descriptions.
@@ -5522,6 +5558,23 @@ components:
         * `2` - Mittwoch
         * `3` - Donnerstag
         * `4` - Freitag
+    FinanceUserCompact:
+      type: object
+      description: Compact user representation for nested display.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+      required:
+      - first_name
+      - id
+      - last_name
     GDPRRetentionConfigResponse:
       type: object
       properties:
@@ -5657,7 +5710,7 @@ components:
           title: Beschreibung
         leader:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/GroupUserCompact'
           readOnly: true
         members:
           type: array
@@ -5733,7 +5786,7 @@ components:
           title: Beschreibung
         leader:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/GroupUserCompact'
           readOnly: true
         member_count:
           type: integer
@@ -5822,7 +5875,7 @@ components:
           readOnly: true
         role:
           allOf:
-          - $ref: '#/components/schemas/Role380Enum'
+          - $ref: '#/components/schemas/GroupMemberRoleEnum'
           title: Rolle in Gruppe
         is_active:
           type: boolean
@@ -5859,7 +5912,7 @@ components:
           title: Benutzer
         role:
           allOf:
-          - $ref: '#/components/schemas/Role380Enum'
+          - $ref: '#/components/schemas/GroupMemberRoleEnum'
           title: Rolle in Gruppe
       required:
       - group
@@ -5877,11 +5930,42 @@ components:
           title: Benutzer
         role:
           allOf:
-          - $ref: '#/components/schemas/Role380Enum'
+          - $ref: '#/components/schemas/GroupMemberRoleEnum'
           title: Rolle in Gruppe
       required:
       - group
       - user
+    GroupMemberRoleEnum:
+      enum:
+      - educator
+      - assistant
+      - substitute
+      type: string
+      description: |-
+        * `educator` - Paedagogin
+        * `assistant` - Assistenz
+        * `substitute` - Vertretung
+    GroupUserCompact:
+      type: object
+      description: Compact user representation for nested display in groups.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        role:
+          type: string
+          readOnly: true
+      required:
+      - first_name
+      - id
+      - last_name
+      - role
     HealthCheckResponse:
       type: object
       properties:
@@ -5993,7 +6077,7 @@ components:
           title: Begruendung
         status:
           allOf:
-          - $ref: '#/components/schemas/LeaveRequestListStatusEnum'
+          - $ref: '#/components/schemas/LeaveRequestStatusEnum'
           readOnly: true
         approved_by:
           allOf:
@@ -6048,7 +6132,7 @@ components:
       - end_date
       - reason
       - start_date
-    LeaveRequestListStatusEnum:
+    LeaveRequestStatusEnum:
       enum:
       - draft
       - pending
@@ -6295,16 +6379,17 @@ components:
           title: Telefon
           maxLength: 255
         groups:
-          type: string
+          type: array
+          items: {}
           readOnly: true
         group_count:
-          type: string
+          type: integer
           readOnly: true
         student_count:
-          type: string
+          type: integer
           readOnly: true
         educator_count:
-          type: string
+          type: integer
           readOnly: true
         is_active:
           type: boolean
@@ -6360,13 +6445,13 @@ components:
           title: PLZ
           maxLength: 20
         group_count:
-          type: string
+          type: integer
           readOnly: true
         student_count:
-          type: string
+          type: integer
           readOnly: true
         educator_count:
-          type: string
+          type: integer
           readOnly: true
         is_active:
           type: boolean
@@ -7126,7 +7211,7 @@ components:
           format: date
           title: Datum
         status:
-          $ref: '#/components/schemas/Status005Enum'
+          $ref: '#/components/schemas/AttendanceStatusEnum'
         notes:
           type: string
           title: Notizen
@@ -7166,7 +7251,7 @@ components:
           title: Benutzer
         role:
           allOf:
-          - $ref: '#/components/schemas/Role380Enum'
+          - $ref: '#/components/schemas/GroupMemberRoleEnum'
           title: Rolle in Gruppe
     PatchedLeaveRequestCreateRequest:
       type: object
@@ -7464,7 +7549,7 @@ components:
           title: Beschreibung
         category_type:
           allOf:
-          - $ref: '#/components/schemas/CategoryTypeEnum'
+          - $ref: '#/components/schemas/TransactionTypeEnum'
           title: Kategorie-Typ
         color:
           type: string
@@ -7554,7 +7639,7 @@ components:
           maxLength: 254
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           title: Rolle
         organization:
           type: integer
@@ -7611,7 +7696,7 @@ components:
           title: Schuljahr
           description: Zugehöriges Schuljahr
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -7691,7 +7776,7 @@ components:
           description: MIME-Type (z.B. image/jpeg, application/pdf)
         uploaded_by:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/FinanceUserCompact'
           readOnly: true
         description:
           type: string
@@ -7709,28 +7794,6 @@ components:
       - file_url
       - id
       - uploaded_by
-    Role08eEnum:
-      enum:
-      - educator
-      - location_manager
-      - admin
-      - super_admin
-      type: string
-      description: |-
-        * `educator` - Pädagogin
-        * `location_manager` - Standortleitung
-        * `admin` - Admin
-        * `super_admin` - Super Admin
-    Role380Enum:
-      enum:
-      - educator
-      - assistant
-      - substitute
-      type: string
-      description: |-
-        * `educator` - Paedagogin
-        * `assistant` - Assistenz
-        * `substitute` - Vertretung
     SchoolYearCreate:
       type: object
       description: Serializer for creating/updating school years.
@@ -7927,38 +7990,6 @@ components:
       - name
       - school_year
       - start_date
-    Status005Enum:
-      enum:
-      - present
-      - absent
-      - sick
-      - excused
-      type: string
-      description: |-
-        * `present` - Anwesend
-        * `absent` - Abwesend
-        * `sick` - Krank
-        * `excused` - Beurlaubt
-    Status90cEnum:
-      enum:
-      - draft
-      - published
-      type: string
-      description: |-
-        * `draft` - Entwurf
-        * `published` - Veröffentlicht
-    StatusF9bEnum:
-      enum:
-      - draft
-      - pending
-      - approved
-      - rejected
-      type: string
-      description: |-
-        * `draft` - Entwurf
-        * `pending` - Ausstehend
-        * `approved` - Genehmigt
-        * `rejected` - Abgelehnt
     StudentCreate:
       type: object
       description: Serializer for creating/updating students.
@@ -8433,7 +8464,7 @@ components:
           title: Beschreibung
         category_type:
           allOf:
-          - $ref: '#/components/schemas/CategoryTypeEnum'
+          - $ref: '#/components/schemas/TransactionTypeEnum'
           title: Kategorie-Typ
         color:
           type: string
@@ -8464,7 +8495,7 @@ components:
           title: Beschreibung
         category_type:
           allOf:
-          - $ref: '#/components/schemas/CategoryTypeEnum'
+          - $ref: '#/components/schemas/TransactionTypeEnum'
           title: Kategorie-Typ
         color:
           type: string
@@ -8497,7 +8528,7 @@ components:
           title: Beschreibung
         category_type:
           allOf:
-          - $ref: '#/components/schemas/CategoryTypeEnum'
+          - $ref: '#/components/schemas/TransactionTypeEnum'
           title: Kategorie-Typ
         color:
           type: string
@@ -8658,15 +8689,15 @@ components:
           title: Transaktionszeit
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusF9bEnum'
+          - $ref: '#/components/schemas/TransactionStatusEnum'
           readOnly: true
         created_by:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/FinanceUserCompact'
           readOnly: true
         approved_by:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/FinanceUserCompact'
           readOnly: true
         approved_at:
           type: string
@@ -8755,15 +8786,15 @@ components:
           title: Transaktionszeit
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusF9bEnum'
+          - $ref: '#/components/schemas/TransactionStatusEnum'
           readOnly: true
         created_by:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/FinanceUserCompact'
           readOnly: true
         approved_by:
           allOf:
-          - $ref: '#/components/schemas/UserCompact'
+          - $ref: '#/components/schemas/FinanceUserCompact'
           readOnly: true
         approved_at:
           type: string
@@ -8834,6 +8865,18 @@ components:
       - group
       - transaction_date
       - transaction_type
+    TransactionStatusEnum:
+      enum:
+      - draft
+      - pending
+      - approved
+      - rejected
+      type: string
+      description: |-
+        * `draft` - Entwurf
+        * `pending` - Ausstehend
+        * `approved` - Genehmigt
+        * `rejected` - Abgelehnt
     TransactionTypeEnum:
       enum:
       - income
@@ -8965,23 +9008,6 @@ components:
           maxLength: 6
       required:
       - code
-    UserCompact:
-      type: object
-      description: Compact user representation for nested display.
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        first_name:
-          type: string
-          readOnly: true
-        last_name:
-          type: string
-          readOnly: true
-      required:
-      - first_name
-      - id
-      - last_name
     UserCreate:
       type: object
       description: Serializer for creating a new user (admin only).
@@ -9011,7 +9037,7 @@ components:
           maxLength: 150
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           title: Rolle
         organization:
           type: integer
@@ -9068,7 +9094,7 @@ components:
           minLength: 8
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           title: Rolle
         organization:
           type: integer
@@ -9125,7 +9151,7 @@ components:
           readOnly: true
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           readOnly: true
           title: Rolle
         role_display:
@@ -9236,7 +9262,7 @@ components:
           readOnly: true
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           readOnly: true
           title: Rolle
         role_display:
@@ -9333,7 +9359,7 @@ components:
           readOnly: true
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           readOnly: true
           title: Rolle
         role_display:
@@ -9418,6 +9444,18 @@ components:
       - role_display
       - terms_accepted_at
       - username
+    UserRoleEnum:
+      enum:
+      - educator
+      - location_manager
+      - admin
+      - super_admin
+      type: string
+      description: |-
+        * `educator` - Pädagogin
+        * `location_manager` - Standortleitung
+        * `admin` - Admin
+        * `super_admin` - Super Admin
     UserUpdate:
       type: object
       description: Serializer for updating a user (admin only).
@@ -9437,7 +9475,7 @@ components:
           maxLength: 254
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           title: Rolle
         organization:
           type: integer
@@ -9479,7 +9517,7 @@ components:
           maxLength: 254
         role:
           allOf:
-          - $ref: '#/components/schemas/Role08eEnum'
+          - $ref: '#/components/schemas/UserRoleEnum'
           title: Rolle
         organization:
           type: integer
@@ -9539,7 +9577,7 @@ components:
           title: Schuljahr
           description: Zugehöriges Schuljahr
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -9593,7 +9631,7 @@ components:
           title: Schuljahr
           description: Zugehöriges Schuljahr
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -9665,9 +9703,10 @@ components:
           readOnly: true
         leader_name:
           type: string
+          description: Return the group leader name if available.
           readOnly: true
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -9896,6 +9935,10 @@ components:
           nullable: true
           title: Wochenbeginn (Montag)
           description: Montag der Kalenderwoche (leer bei Vorlagen)
+        week_end_date:
+          type: string
+          format: date
+          readOnly: true
         calendar_week:
           type: integer
           readOnly: true
@@ -9906,12 +9949,13 @@ components:
           maxLength: 255
         weekly_theme_preview:
           type: string
+          description: Return first 100 chars of weekly_theme, stripped of HTML tags.
           readOnly: true
         school_year_name:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -9929,7 +9973,7 @@ components:
           type: string
           readOnly: true
         entry_count:
-          type: string
+          type: integer
           readOnly: true
         created_at:
           type: string
@@ -9951,6 +9995,7 @@ components:
       - location_name
       - school_year_name
       - updated_at
+      - week_end_date
       - weekly_theme_preview
     WeeklyPlanListRequest:
       type: object
@@ -9973,7 +10018,7 @@ components:
           description: Optionaler Titel (z.B. 'Projektwoche Natur')
           maxLength: 255
         status:
-          $ref: '#/components/schemas/Status90cEnum'
+          $ref: '#/components/schemas/WeeklyPlanStatusEnum'
         is_template:
           type: boolean
           title: Ist Vorlage
@@ -9987,6 +10032,14 @@ components:
           type: integer
           nullable: true
           title: Erstellt von
+    WeeklyPlanStatusEnum:
+      enum:
+      - draft
+      - published
+      type: string
+      description: |-
+        * `draft` - Entwurf
+        * `published` - Veröffentlicht
     WorkingHoursLimit:
       type: object
       description: Serializer for working hours limits.
@@ -10101,6 +10154,8 @@ tags:
   description: Zeiterfassung & Arbeitszeiten
 - name: Groups
   description: Gruppen- & Schülerverwaltung
+- name: WeeklyPlans
+  description: Wochenpläne & Tagesaktivitäten
 - name: Admin
   description: Admin-Funktionen & Systemverwaltung
 - name: System

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -5069,6 +5069,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/WeeklyPlanList'
           description: ''
+  /api/v1/weeklyplans/{id}/duplicate-entry/:
+    post:
+      operationId: weeklyplans_duplicate_entry_create
+      description: |-
+        Duplicate a single entry within the same weekly plan to a different day.
+        Expects: { "entry_id": <int>, "target_day": <int 0-4> }
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: Ein eindeutiger Ganzzahl-Wert, der Wochenplan identifiziert.
+        required: true
+      tags:
+      - weeklyplans
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WeeklyPlanListRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/WeeklyPlanListRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/WeeklyPlanListRequest'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklyPlanList'
+          description: ''
   /api/v1/weeklyplans/{id}/pdf/:
     get:
       operationId: weeklyplans_pdf_retrieve

--- a/backend/weeklyplans/models.py
+++ b/backend/weeklyplans/models.py
@@ -118,15 +118,22 @@ class WeeklyPlan(TenantModel):
     def calendar_week(self):
         """Return the ISO calendar week number."""
         if self.week_start_date:
-            return self.week_start_date.isocalendar()[1]
+            import datetime as _dt
+            d = self.week_start_date
+            if isinstance(d, str):
+                d = _dt.date.fromisoformat(d)
+            return d.isocalendar()[1]
         return None
 
     @property
     def week_end_date(self):
         """Return the Friday of the same week."""
         if self.week_start_date:
-            import datetime
-            return self.week_start_date + datetime.timedelta(days=4)
+            import datetime as _dt
+            d = self.week_start_date
+            if isinstance(d, str):
+                d = _dt.date.fromisoformat(d)
+            return d + _dt.timedelta(days=4)
         return None
 
 

--- a/backend/weeklyplans/serializers.py
+++ b/backend/weeklyplans/serializers.py
@@ -18,7 +18,7 @@ class WeeklyPlanEntrySerializer(serializers.ModelSerializer):
             "activity", "description", "color", "category", "sort_order",
         ]
 
-    def get_day_name(self, obj):
+    def get_day_name(self, obj) -> str:
         return dict(WeeklyPlanEntry.DAY_CHOICES).get(obj.day_of_week, "")
 
 
@@ -42,7 +42,7 @@ class DailyActivitySerializer(serializers.ModelSerializer):
         model = DailyActivity
         fields = ["id", "day_of_week", "day_name", "content"]
 
-    def get_day_name(self, obj):
+    def get_day_name(self, obj) -> str:
         return dict(DailyActivity.DAY_CHOICES).get(obj.day_of_week, "")
 
 
@@ -61,6 +61,7 @@ class WeeklyPlanListSerializer(serializers.ModelSerializer):
     location_name = serializers.SerializerMethodField()
     created_by_name = serializers.SerializerMethodField()
     calendar_week = serializers.IntegerField(read_only=True)
+    week_end_date = serializers.DateField(read_only=True)
     entry_count = serializers.SerializerMethodField()
     school_year_name = serializers.SerializerMethodField()
     weekly_theme_preview = serializers.SerializerMethodField()
@@ -69,32 +70,32 @@ class WeeklyPlanListSerializer(serializers.ModelSerializer):
         model = WeeklyPlan
         fields = [
             "id", "group", "group_name", "location_name",
-            "week_start_date", "calendar_week", "title",
+            "week_start_date", "week_end_date", "calendar_week", "title",
             "weekly_theme_preview", "school_year_name",
             "status", "is_template", "template_name",
             "created_by", "created_by_name", "entry_count",
             "created_at", "updated_at",
         ]
 
-    def get_location_name(self, obj):
+    def get_location_name(self, obj) -> str:
         if obj.group and obj.group.location:
             return obj.group.location.name
         return ""
 
-    def get_created_by_name(self, obj):
+    def get_created_by_name(self, obj) -> str:
         if obj.created_by:
             return f"{obj.created_by.first_name} {obj.created_by.last_name}".strip()
         return ""
 
-    def get_entry_count(self, obj):
+    def get_entry_count(self, obj) -> int:
         return obj.entries.count()
 
-    def get_school_year_name(self, obj):
+    def get_school_year_name(self, obj) -> str:
         if obj.school_year:
             return str(obj.school_year)
         return ""
 
-    def get_weekly_theme_preview(self, obj):
+    def get_weekly_theme_preview(self, obj) -> str:
         """Return first 100 chars of weekly_theme, stripped of HTML tags."""
         if not obj.weekly_theme:
             return ""
@@ -128,22 +129,22 @@ class WeeklyPlanDetailSerializer(serializers.ModelSerializer):
             "created_at", "updated_at",
         ]
 
-    def get_location_name(self, obj):
+    def get_location_name(self, obj) -> str:
         if obj.group and obj.group.location:
             return obj.group.location.name
         return ""
 
-    def get_created_by_name(self, obj):
+    def get_created_by_name(self, obj) -> str:
         if obj.created_by:
             return f"{obj.created_by.first_name} {obj.created_by.last_name}".strip()
         return ""
 
-    def get_school_year_name(self, obj):
+    def get_school_year_name(self, obj) -> str:
         if obj.school_year:
             return str(obj.school_year)
         return ""
 
-    def get_leader_name(self, obj):
+    def get_leader_name(self, obj) -> str:
         """Return the group leader name if available."""
         if obj.group and hasattr(obj.group, "leader") and obj.group.leader:
             leader = obj.group.leader

--- a/backend/weeklyplans/tests/test_api.py
+++ b/backend/weeklyplans/tests/test_api.py
@@ -1,0 +1,560 @@
+"""
+API tests for WeeklyPlans endpoints.
+Tests CRUD operations, duplication, entry duplication, templates, and RBAC.
+"""
+
+import datetime
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.models import Location, Organization, User
+from groups.models import Group, SchoolYear
+from weeklyplans.models import DailyActivity, WeeklyPlan, WeeklyPlanEntry
+
+
+class WeeklyPlanAPITestBase(TestCase):
+    """Base class with shared setup for weekly plan API tests."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.org = Organization.objects.create(name="Test Org")
+        self.location = Location.objects.create(
+            name="Test Standort",
+            organization=self.org,
+            city="Wien",
+            postal_code="1010",
+            street="Teststr 1",
+        )
+        self.educator = User.objects.create_user(
+            username="educator",
+            password="TestPass123!",
+            role="educator",
+            location=self.location,
+            first_name="Test",
+            last_name="Educator",
+        )
+        self.manager = User.objects.create_user(
+            username="manager",
+            password="TestPass123!",
+            role="location_manager",
+            location=self.location,
+            first_name="Test",
+            last_name="Manager",
+        )
+        self.admin = User.objects.create_user(
+            username="admin",
+            password="TestPass123!",
+            role="admin",
+            location=self.location,
+            first_name="Test",
+            last_name="Admin",
+        )
+        self.school_year = SchoolYear.objects.create(
+            name="2025/2026",
+            location=self.location,
+            start_date="2025-09-01",
+            end_date="2026-06-30",
+        )
+        self.group = Group.objects.create(
+            name="Testgruppe",
+            location=self.location,
+            school_year=self.school_year,
+            leader=self.educator,
+        )
+        self.base_url = "/api/v1/weeklyplans/"
+
+    def create_plan(self, **kwargs):
+        """Helper to create a weekly plan."""
+        defaults = {
+            "group": self.group,
+            "week_start_date": datetime.date(2026, 3, 23),
+            "title": "Wochenplan KW 13",
+            "status": "draft",
+            "created_by": self.educator,
+            "organization": self.org,
+        }
+        defaults.update(kwargs)
+        return WeeklyPlan.objects.create(**defaults)
+
+    def create_entry(self, plan, **kwargs):
+        """Helper to create a weekly plan entry."""
+        defaults = {
+            "weekly_plan": plan,
+            "day_of_week": 0,
+            "start_time": "12:00",
+            "end_time": "13:00",
+            "activity": "Mittagessen",
+            "category": "essen",
+            "sort_order": 0,
+        }
+        defaults.update(kwargs)
+        return WeeklyPlanEntry.objects.create(**defaults)
+
+
+class WeeklyPlanListTest(WeeklyPlanAPITestBase):
+    """Tests for GET /api/weeklyplans/."""
+
+    def test_unauthenticated_returns_401(self):
+        """Unauthenticated requests should be rejected."""
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_educator_sees_own_group_plans(self):
+        """Educator should see plans for their groups."""
+        self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_list_contains_calendar_week(self):
+        """List response should include calendar_week."""
+        self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.data["results"][0]["calendar_week"], 13)
+
+    def test_list_contains_week_end_date(self):
+        """List response should include week_end_date."""
+        self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.data["results"][0]["week_end_date"], "2026-03-27")
+
+    def test_filter_by_status(self):
+        """Filter by status should work."""
+        self.create_plan(status="draft")
+        self.create_plan(
+            status="published",
+            week_start_date=datetime.date(2026, 3, 30),
+            title="Published Plan",
+        )
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url, {"status": "published"})
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["status"], "published")
+
+    def test_filter_by_group(self):
+        """Filter by group should work."""
+        self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url, {"group": self.group.id})
+        self.assertEqual(response.data["count"], 1)
+
+    def test_filter_by_is_template(self):
+        """Filter by is_template should work."""
+        self.create_plan(is_template=False)
+        self.create_plan(
+            is_template=True,
+            template_name="Standard",
+            title="Template",
+            week_start_date=None,
+        )
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url, {"is_template": "false"})
+        self.assertEqual(response.data["count"], 1)
+
+    def test_search_by_title(self):
+        """Search by title should work."""
+        self.create_plan(title="Spezialwoche Frühling")
+        self.create_plan(
+            title="Normal",
+            week_start_date=datetime.date(2026, 3, 30),
+        )
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url, {"search": "Frühling"})
+        self.assertEqual(response.data["count"], 1)
+
+    def test_manager_sees_all_location_plans(self):
+        """Location manager should see all plans for their location."""
+        self.create_plan()
+        self.client.force_authenticate(user=self.manager)
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_soft_deleted_plans_hidden(self):
+        """Soft-deleted plans should not appear in list."""
+        plan = self.create_plan()
+        plan.is_deleted = True
+        plan.save()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.data["count"], 0)
+
+
+class WeeklyPlanDetailTest(WeeklyPlanAPITestBase):
+    """Tests for GET /api/weeklyplans/{id}/."""
+
+    def test_retrieve_plan_with_entries(self):
+        """Retrieve should return plan with nested entries."""
+        plan = self.create_plan()
+        self.create_entry(plan)
+        self.create_entry(plan, day_of_week=1, activity="Lernstunde")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(f"{self.base_url}{plan.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["entries"]), 2)
+        self.assertIn("calendar_week", response.data)
+        self.assertIn("week_end_date", response.data)
+
+    def test_retrieve_plan_with_daily_activities(self):
+        """Retrieve should return plan with daily activities."""
+        plan = self.create_plan()
+        DailyActivity.objects.create(
+            weekly_plan=plan,
+            day_of_week=0,
+            content="<p>Basteln</p>",
+        )
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(f"{self.base_url}{plan.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["daily_activities"]), 1)
+        self.assertIn("Basteln", response.data["daily_activities"][0]["content"])
+
+    def test_retrieve_plan_with_weekly_theme(self):
+        """Retrieve should return plan with weekly_theme."""
+        plan = self.create_plan(weekly_theme="<p>Frühling</p>")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(f"{self.base_url}{plan.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Frühling", response.data["weekly_theme"])
+
+
+class WeeklyPlanCreateTest(WeeklyPlanAPITestBase):
+    """Tests for POST /api/weeklyplans/."""
+
+    def test_create_plan_with_entries(self):
+        """Create a plan with entries."""
+        self.client.force_authenticate(user=self.educator)
+        data = {
+            "group": self.group.id,
+            "week_start_date": "2026-04-06",
+            "title": "Neue Woche",
+            "status": "draft",
+            "entries": [
+                {
+                    "day_of_week": 0,
+                    "start_time": "12:00",
+                    "end_time": "13:00",
+                    "activity": "Mittagessen",
+                    "category": "essen",
+                    "sort_order": 0,
+                },
+                {
+                    "day_of_week": 0,
+                    "start_time": "13:00",
+                    "end_time": "14:00",
+                    "activity": "Lernstunde",
+                    "category": "lernen",
+                    "sort_order": 1,
+                },
+            ],
+        }
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        plan = WeeklyPlan.objects.get(id=response.data["id"])
+        self.assertEqual(plan.entries.count(), 2)
+
+    def test_create_plan_without_entries_gets_defaults(self):
+        """Create a plan without entries should generate default time slots."""
+        self.client.force_authenticate(user=self.educator)
+        data = {
+            "group": self.group.id,
+            "week_start_date": "2026-04-06",
+            "title": "Default Slots",
+            "status": "draft",
+        }
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        plan = WeeklyPlan.objects.get(id=response.data["id"])
+        # 5 default slots * 5 days = 25 entries
+        self.assertEqual(plan.entries.count(), 25)
+
+    def test_create_plan_with_daily_activities(self):
+        """Create a plan with daily activities."""
+        self.client.force_authenticate(user=self.educator)
+        data = {
+            "group": self.group.id,
+            "week_start_date": "2026-04-06",
+            "title": "Mit Tagesaktivitäten",
+            "status": "draft",
+            "entries": [
+                {
+                    "day_of_week": 0,
+                    "start_time": "12:00",
+                    "end_time": "13:00",
+                    "activity": "Mittagessen",
+                    "category": "essen",
+                    "sort_order": 0,
+                },
+            ],
+            "daily_activities": [
+                {"day_of_week": 0, "content": "<p>Basteln</p>"},
+                {"day_of_week": 1, "content": "<p>Sport</p>"},
+            ],
+        }
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        plan = WeeklyPlan.objects.get(id=response.data["id"])
+        self.assertEqual(plan.daily_activities.count(), 2)
+
+    def test_create_plan_with_weekly_theme(self):
+        """Create a plan with weekly_theme."""
+        self.client.force_authenticate(user=self.educator)
+        data = {
+            "group": self.group.id,
+            "week_start_date": "2026-04-06",
+            "title": "Themenwoche",
+            "weekly_theme": "<p><strong>Frühling</strong></p>",
+            "status": "draft",
+            "entries": [],
+        }
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        plan = WeeklyPlan.objects.get(id=response.data["id"])
+        self.assertIn("Frühling", plan.weekly_theme)
+
+
+class WeeklyPlanUpdateTest(WeeklyPlanAPITestBase):
+    """Tests for PUT/PATCH /api/weeklyplans/{id}/."""
+
+    def test_update_plan_title(self):
+        """Update plan title via PATCH."""
+        plan = self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.patch(
+            f"{self.base_url}{plan.id}/",
+            {"title": "Neuer Titel"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        plan.refresh_from_db()
+        self.assertEqual(plan.title, "Neuer Titel")
+
+    def test_update_plan_entries_replaces_all(self):
+        """Update entries should replace all existing entries."""
+        plan = self.create_plan()
+        self.create_entry(plan)
+        self.create_entry(plan, day_of_week=1, activity="Alt")
+        self.assertEqual(plan.entries.count(), 2)
+
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.patch(
+            f"{self.base_url}{plan.id}/",
+            {
+                "entries": [
+                    {
+                        "day_of_week": 0,
+                        "start_time": "12:00",
+                        "end_time": "13:00",
+                        "activity": "Nur ein Eintrag",
+                        "category": "essen",
+                        "sort_order": 0,
+                    },
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        plan.refresh_from_db()
+        self.assertEqual(plan.entries.count(), 1)
+        self.assertEqual(plan.entries.first().activity, "Nur ein Eintrag")
+
+    def test_update_plan_status(self):
+        """Update plan status to published."""
+        plan = self.create_plan(status="draft")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.patch(
+            f"{self.base_url}{plan.id}/",
+            {"status": "published"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        plan.refresh_from_db()
+        self.assertEqual(plan.status, "published")
+
+
+class WeeklyPlanDeleteTest(WeeklyPlanAPITestBase):
+    """Tests for DELETE /api/weeklyplans/{id}/."""
+
+    def test_delete_is_soft_delete(self):
+        """Delete should set is_deleted=True, not remove from DB."""
+        plan = self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.delete(f"{self.base_url}{plan.id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        plan.refresh_from_db()
+        self.assertTrue(plan.is_deleted)
+        # Plan still exists in DB
+        self.assertTrue(WeeklyPlan.objects.filter(id=plan.id).exists())
+
+
+class WeeklyPlanDuplicateTest(WeeklyPlanAPITestBase):
+    """Tests for POST /api/weeklyplans/{id}/duplicate/."""
+
+    def test_duplicate_plan(self):
+        """Duplicate a plan for a new week."""
+        plan = self.create_plan()
+        self.create_entry(plan)
+        self.create_entry(plan, day_of_week=1, activity="Lernstunde")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate/",
+            {"week_start_date": "2026-03-30"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        new_plan = WeeklyPlan.objects.get(id=response.data["id"])
+        self.assertEqual(new_plan.week_start_date, datetime.date(2026, 3, 30))
+        self.assertEqual(new_plan.entries.count(), 2)
+        self.assertEqual(new_plan.status, "draft")
+
+    def test_duplicate_without_date_returns_400(self):
+        """Duplicate without week_start_date should return 400."""
+        plan = self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate/",
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class WeeklyPlanDuplicateEntryTest(WeeklyPlanAPITestBase):
+    """Tests for POST /api/weeklyplans/{id}/duplicate-entry/."""
+
+    def test_duplicate_entry_to_another_day(self):
+        """Duplicate an entry to a different day."""
+        plan = self.create_plan()
+        entry = self.create_entry(plan, day_of_week=0, activity="Mittagessen")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate-entry/",
+            {"entry_id": entry.id, "target_day": 2},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(plan.entries.count(), 2)
+        new_entry = plan.entries.exclude(id=entry.id).first()
+        self.assertEqual(new_entry.day_of_week, 2)
+        self.assertEqual(new_entry.activity, "Mittagessen")
+        # Compare as string since entry fixture uses string, DB returns time
+        self.assertEqual(str(new_entry.start_time)[:5], str(entry.start_time)[:5])
+        self.assertEqual(str(new_entry.end_time)[:5], str(entry.end_time)[:5])
+
+    def test_duplicate_entry_same_day(self):
+        """Duplicate an entry to the same day should work."""
+        plan = self.create_plan()
+        entry = self.create_entry(plan, day_of_week=0)
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate-entry/",
+            {"entry_id": entry.id, "target_day": 0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(plan.entries.count(), 2)
+
+    def test_duplicate_entry_missing_params(self):
+        """Missing entry_id or target_day should return 400."""
+        plan = self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate-entry/",
+            {"entry_id": 999},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_duplicate_entry_invalid_day(self):
+        """Invalid target_day should return 400."""
+        plan = self.create_plan()
+        entry = self.create_entry(plan)
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate-entry/",
+            {"entry_id": entry.id, "target_day": 7},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_duplicate_entry_not_found(self):
+        """Non-existent entry_id should return 404."""
+        plan = self.create_plan()
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/duplicate-entry/",
+            {"entry_id": 99999, "target_day": 1},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class WeeklyPlanTemplateTest(WeeklyPlanAPITestBase):
+    """Tests for template-related endpoints."""
+
+    def test_list_templates(self):
+        """GET /api/weeklyplans/templates/ should return only templates."""
+        self.create_plan(is_template=False)
+        self.create_plan(
+            is_template=True,
+            template_name="Standard GTS",
+            title="Template",
+        )
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(f"{self.base_url}templates/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertTrue(response.data[0]["is_template"])
+
+    def test_create_from_template(self):
+        """POST /api/weeklyplans/{id}/create-from-template/ should create a new plan."""
+        template = self.create_plan(
+            is_template=True,
+            template_name="Standard",
+            title="Template",
+        )
+        self.create_entry(template, activity="Template-Eintrag")
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{template.id}/create-from-template/",
+            {"week_start_date": "2026-04-06", "group": self.group.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        new_plan = WeeklyPlan.objects.get(id=response.data["id"])
+        self.assertFalse(new_plan.is_template)
+        self.assertEqual(new_plan.entries.count(), 1)
+        self.assertEqual(new_plan.entries.first().activity, "Template-Eintrag")
+
+    def test_create_from_non_template_returns_400(self):
+        """Creating from a non-template plan should return 400."""
+        plan = self.create_plan(is_template=False)
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.post(
+            f"{self.base_url}{plan.id}/create-from-template/",
+            {"week_start_date": "2026-04-06", "group": self.group.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class WeeklyPlanPDFTest(WeeklyPlanAPITestBase):
+    """Tests for GET /api/weeklyplans/{id}/pdf/."""
+
+    def test_pdf_export(self):
+        """PDF export should return a response (HTML fallback or PDF)."""
+        plan = self.create_plan()
+        self.create_entry(plan)
+        self.client.force_authenticate(user=self.educator)
+        response = self.client.get(f"{self.base_url}{plan.id}/pdf/")
+        self.assertIn(response.status_code, [status.HTTP_200_OK])
+        # Should be either PDF or HTML
+        self.assertIn(
+            response["Content-Type"],
+            ["application/pdf", "text/html; charset=utf-8"],
+        )

--- a/backend/weeklyplans/tests/test_models.py
+++ b/backend/weeklyplans/tests/test_models.py
@@ -1,0 +1,327 @@
+"""
+Model tests for WeeklyPlans: WeeklyPlan, WeeklyPlanEntry, DailyActivity.
+"""
+
+import datetime
+
+from django.test import TestCase
+
+from core.models import Location, Organization, User
+from groups.models import Group, SchoolYear
+from weeklyplans.models import DailyActivity, WeeklyPlan, WeeklyPlanEntry
+
+
+class WeeklyPlanModelTestBase(TestCase):
+    """Base class with shared setup for weekly plan model tests."""
+
+    def setUp(self):
+        self.org = Organization.objects.create(name="Test Org")
+        self.location = Location.objects.create(
+            name="Test Standort",
+            organization=self.org,
+            city="Wien",
+            postal_code="1010",
+            street="Teststr 1",
+        )
+        self.educator = User.objects.create_user(
+            username="educator",
+            password="TestPass123!",
+            role="educator",
+            location=self.location,
+            first_name="Test",
+            last_name="Educator",
+        )
+        self.school_year = SchoolYear.objects.create(
+            name="2025/2026",
+            location=self.location,
+            start_date="2025-09-01",
+            end_date="2026-06-30",
+        )
+        self.group = Group.objects.create(
+            name="Testgruppe",
+            location=self.location,
+            school_year=self.school_year,
+            leader=self.educator,
+        )
+
+
+class WeeklyPlanModelTest(WeeklyPlanModelTestBase):
+    """Tests for the WeeklyPlan model."""
+
+    def test_create_weekly_plan(self):
+        """Test creating a basic weekly plan."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Wochenplan KW 13",
+            status="draft",
+            created_by=self.educator,
+            organization=self.org,
+        )
+        self.assertEqual(plan.title, "Wochenplan KW 13")
+        self.assertEqual(plan.status, "draft")
+        self.assertFalse(plan.is_template)
+        self.assertFalse(plan.is_deleted)
+
+    def test_calendar_week_property(self):
+        """Test the calendar_week property returns correct ISO week."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test KW",
+            organization=self.org,
+        )
+        self.assertEqual(plan.calendar_week, 13)
+
+    def test_calendar_week_none_when_no_date(self):
+        """Test calendar_week returns None for templates without date."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            title="Template",
+            is_template=True,
+            organization=self.org,
+        )
+        self.assertIsNone(plan.calendar_week)
+
+    def test_week_end_date_property(self):
+        """Test the week_end_date property returns Friday."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),  # Monday
+            title="Test",
+            organization=self.org,
+        )
+        self.assertEqual(plan.week_end_date, datetime.date(2026, 3, 27))  # Friday
+
+    def test_week_end_date_none_when_no_date(self):
+        """Test week_end_date returns None for templates without date."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            title="Template",
+            is_template=True,
+            organization=self.org,
+        )
+        self.assertIsNone(plan.week_end_date)
+
+    def test_str_with_date(self):
+        """Test __str__ for plan with date."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test",
+            organization=self.org,
+        )
+        self.assertIn("KW 13", str(plan))
+        self.assertIn("Testgruppe", str(plan))
+
+    def test_str_template(self):
+        """Test __str__ for template plan."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            title="Template",
+            is_template=True,
+            template_name="Standard GTS",
+            organization=self.org,
+        )
+        self.assertIn("Vorlage", str(plan))
+        self.assertIn("Standard GTS", str(plan))
+
+    def test_weekly_theme_field(self):
+        """Test that weekly_theme field stores HTML content."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test",
+            weekly_theme="<p><strong>Frühling</strong> – Natur entdecken</p>",
+            organization=self.org,
+        )
+        self.assertIn("<strong>Frühling</strong>", plan.weekly_theme)
+
+    def test_soft_delete(self):
+        """Test that is_deleted flag works correctly."""
+        plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test",
+            organization=self.org,
+        )
+        plan.is_deleted = True
+        plan.save()
+        self.assertTrue(plan.is_deleted)
+        # Soft-deleted plans should still exist in DB
+        self.assertEqual(WeeklyPlan.objects.filter(id=plan.id).count(), 1)
+
+    def test_ordering(self):
+        """Test default ordering is by week_start_date descending."""
+        plan1 = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 16),
+            title="KW 12",
+            organization=self.org,
+        )
+        plan2 = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="KW 13",
+            organization=self.org,
+        )
+        plans = list(WeeklyPlan.objects.all())
+        self.assertEqual(plans[0].id, plan2.id)
+        self.assertEqual(plans[1].id, plan1.id)
+
+
+class WeeklyPlanEntryModelTest(WeeklyPlanModelTestBase):
+    """Tests for the WeeklyPlanEntry model."""
+
+    def setUp(self):
+        super().setUp()
+        self.plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test Plan",
+            organization=self.org,
+        )
+
+    def test_create_entry(self):
+        """Test creating a basic entry."""
+        entry = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Mittagessen",
+            category="essen",
+        )
+        self.assertEqual(entry.activity, "Mittagessen")
+        self.assertEqual(entry.day_of_week, 0)
+
+    def test_auto_color_from_category(self):
+        """Test that color is auto-set from category on save."""
+        entry = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Mittagessen",
+            category="essen",
+        )
+        self.assertEqual(entry.color, "#F97316")
+
+    def test_explicit_color_not_overridden(self):
+        """Test that explicit color is not overridden by category."""
+        entry = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Test",
+            category="essen",
+            color="#FF0000",
+        )
+        self.assertEqual(entry.color, "#FF0000")
+
+    def test_str_representation(self):
+        """Test __str__ for entry."""
+        entry = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Mittagessen",
+            category="essen",
+        )
+        self.assertIn("Montag", str(entry))
+        self.assertIn("Mittagessen", str(entry))
+
+    def test_ordering(self):
+        """Test default ordering by day_of_week, start_time."""
+        entry2 = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=1,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Dienstag",
+            category="sonstiges",
+        )
+        entry1 = WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Montag",
+            category="sonstiges",
+        )
+        entries = list(self.plan.entries.all())
+        self.assertEqual(entries[0].id, entry1.id)
+        self.assertEqual(entries[1].id, entry2.id)
+
+    def test_cascade_delete(self):
+        """Test that entries are deleted when plan is deleted."""
+        WeeklyPlanEntry.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            start_time="12:00",
+            end_time="13:00",
+            activity="Test",
+            category="sonstiges",
+        )
+        self.assertEqual(WeeklyPlanEntry.objects.count(), 1)
+        self.plan.delete()
+        self.assertEqual(WeeklyPlanEntry.objects.count(), 0)
+
+
+class DailyActivityModelTest(WeeklyPlanModelTestBase):
+    """Tests for the DailyActivity model."""
+
+    def setUp(self):
+        super().setUp()
+        self.plan = WeeklyPlan.objects.create(
+            group=self.group,
+            week_start_date=datetime.date(2026, 3, 23),
+            title="Test Plan",
+            organization=self.org,
+        )
+
+    def test_create_daily_activity(self):
+        """Test creating a daily activity."""
+        da = DailyActivity.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            content="<p>Basteln mit Naturmaterialien</p>",
+        )
+        self.assertEqual(da.day_of_week, 0)
+        self.assertIn("Basteln", da.content)
+
+    def test_unique_together(self):
+        """Test that only one activity per day per plan is allowed."""
+        DailyActivity.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            content="Erste Aktivität",
+        )
+        with self.assertRaises(Exception):
+            DailyActivity.objects.create(
+                weekly_plan=self.plan,
+                day_of_week=0,
+                content="Zweite Aktivität",
+            )
+
+    def test_str_representation(self):
+        """Test __str__ for daily activity."""
+        da = DailyActivity.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=2,
+            content="Mittwoch Aktivität",
+        )
+        self.assertIn("Mittwoch", str(da))
+
+    def test_cascade_delete(self):
+        """Test that daily activities are deleted when plan is deleted."""
+        DailyActivity.objects.create(
+            weekly_plan=self.plan,
+            day_of_week=0,
+            content="Test",
+        )
+        self.assertEqual(DailyActivity.objects.count(), 1)
+        self.plan.delete()
+        self.assertEqual(DailyActivity.objects.count(), 0)

--- a/backend/weeklyplans/views.py
+++ b/backend/weeklyplans/views.py
@@ -165,6 +165,59 @@ class WeeklyPlanViewSet(TenantViewSetMixin, viewsets.ModelViewSet):
         serializer = WeeklyPlanDetailSerializer(new_plan)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    @action(detail=True, methods=["post"], url_path="duplicate-entry")
+    def duplicate_entry(self, request, pk=None):
+        """
+        Duplicate a single entry within the same weekly plan to a different day.
+        Expects: { "entry_id": <int>, "target_day": <int 0-4> }
+        """
+        plan = self.get_object()
+        entry_id = request.data.get("entry_id")
+        target_day = request.data.get("target_day")
+
+        if entry_id is None or target_day is None:
+            return Response(
+                {"detail": "entry_id und target_day sind erforderlich."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            target_day = int(target_day)
+        except (ValueError, TypeError):
+            return Response(
+                {"detail": "target_day muss eine Zahl zwischen 0 und 4 sein."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if target_day not in range(5):
+            return Response(
+                {"detail": "target_day muss zwischen 0 (Montag) und 4 (Freitag) liegen."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            source_entry = plan.entries.get(id=entry_id)
+        except WeeklyPlanEntry.DoesNotExist:
+            return Response(
+                {"detail": "Eintrag nicht gefunden."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        new_entry = WeeklyPlanEntry.objects.create(
+            weekly_plan=plan,
+            day_of_week=target_day,
+            start_time=source_entry.start_time,
+            end_time=source_entry.end_time,
+            activity=source_entry.activity,
+            description=source_entry.description,
+            color=source_entry.color,
+            category=source_entry.category,
+            sort_order=source_entry.sort_order,
+        )
+
+        serializer = WeeklyPlanDetailSerializer(plan)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
     @action(detail=True, methods=["post"], url_path="create-from-template")
     def create_from_template(self, request, pk=None):
         """

--- a/frontend/src/app/(dashboard)/weeklyplans/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/weeklyplans/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   useUpdateWeeklyPlan,
   useExportPdf,
   useDuplicateWeeklyPlan,
+  useDuplicateEntry,
 } from "@/hooks/use-weeklyplans";
 import { usePermissions } from "@/hooks/use-permissions";
 import { useToast } from "@/components/ui/toast";
@@ -108,6 +109,12 @@ export default function WeeklyPlanDetailPage() {
   const updateMutation = useUpdateWeeklyPlan();
   const exportPdf = useExportPdf();
   const duplicateMutation = useDuplicateWeeklyPlan();
+  const duplicateEntryMutation = useDuplicateEntry();
+
+  // Duplicate entry dialog
+  const [duplicateEntryDialog, setDuplicateEntryDialog] = useState(false);
+  const [duplicateSourceEntry, setDuplicateSourceEntry] = useState<WeeklyPlanEntry | null>(null);
+  const [duplicateTargetDay, setDuplicateTargetDay] = useState<string>("0");
 
   // Edit mode
   const [isEditing, setIsEditing] = useState(searchParams.get("edit") === "true");
@@ -237,6 +244,30 @@ export default function WeeklyPlanDetailPage() {
     }
   };
 
+  const handleDuplicateEntry = async () => {
+    if (!duplicateSourceEntry?.id || !plan) return;
+    try {
+      await duplicateEntryMutation.mutateAsync({
+        planId: plan.id,
+        entryId: duplicateSourceEntry.id,
+        targetDay: Number(duplicateTargetDay),
+      });
+      toast.success("Eintrag erfolgreich dupliziert");
+      setDuplicateEntryDialog(false);
+      setDuplicateSourceEntry(null);
+    } catch {
+      toast.error("Fehler", "Eintrag konnte nicht dupliziert werden.");
+    }
+  };
+
+  const openDuplicateEntryDialog = (entry: WeeklyPlanEntry) => {
+    setDuplicateSourceEntry(entry);
+    // Default to next day
+    const nextDay = entry.day_of_week < 4 ? entry.day_of_week + 1 : 0;
+    setDuplicateTargetDay(String(nextDay));
+    setDuplicateEntryDialog(true);
+  };
+
   const handleDuplicate = async () => {
     try {
       await duplicateMutation.mutateAsync(planId);
@@ -298,16 +329,25 @@ export default function WeeklyPlanDetailPage() {
             ) : (
               <h1 className="text-3xl font-bold tracking-tight">{plan.title}</h1>
             )}
-            <div className="mt-1 flex items-center gap-2 text-muted-foreground">
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-muted-foreground">
               <CalendarDays className="h-4 w-4" />
               <span>KW {plan.calendar_week}</span>
-              <span>·</span>
+              {plan.week_start_date && (
+                <span className="text-xs">
+                  ({new Date(plan.week_start_date).toLocaleDateString("de-AT", { day: "2-digit", month: "2-digit", year: "numeric" })}
+                  {" \u2013 "}
+                  {plan.week_end_date
+                    ? new Date(plan.week_end_date).toLocaleDateString("de-AT", { day: "2-digit", month: "2-digit", year: "numeric" })
+                    : ""})
+                </span>
+              )}
+              <span>\u00b7</span>
               <span>{plan.group_name}</span>
-              <span>·</span>
+              <span>\u00b7</span>
               <span>{plan.location_name}</span>
-              <span>·</span>
+              <span>\u00b7</span>
               <Badge variant={plan.status === "published" ? "default" : "secondary"}>
-                {plan.status === "published" ? "Veröffentlicht" : "Entwurf"}
+                {plan.status === "published" ? "Ver\u00f6ffentlicht" : "Entwurf"}
               </Badge>
             </div>
           </div>
@@ -391,6 +431,24 @@ export default function WeeklyPlanDetailPage() {
         <Card>
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground">{plan.notes}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Weekly Theme */}
+      {!isEditing && plan.weekly_theme && (
+        <Card className="border-yellow-400 dark:border-yellow-600">
+          <CardHeader className="bg-yellow-50 dark:bg-yellow-950/30">
+            <CardTitle className="flex items-center gap-2 text-yellow-800 dark:text-yellow-200">
+              <span className="text-lg">\u2b50</span>
+              Thema der Woche
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="bg-yellow-50/50 pt-4 dark:bg-yellow-950/20">
+            <div
+              className="prose prose-sm dark:prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: plan.weekly_theme }}
+            />
           </CardContent>
         </Card>
       )}
@@ -494,7 +552,7 @@ export default function WeeklyPlanDetailPage() {
                                     {getCategoryLabel(entry.category)}
                                   </span>
                                 </div>
-                                {isEditing && (
+                                {isEditing ? (
                                   <button
                                     className="mt-1 text-[10px] text-destructive hover:underline"
                                     onClick={(e) => {
@@ -504,6 +562,19 @@ export default function WeeklyPlanDetailPage() {
                                   >
                                     Entfernen
                                   </button>
+                                ) : (
+                                  entry.id && (
+                                    <button
+                                      className="mt-1 flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-primary hover:underline"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        openDuplicateEntryDialog(entry);
+                                      }}
+                                    >
+                                      <Copy className="h-2.5 w-2.5" />
+                                      Duplizieren
+                                    </button>
+                                  )
                                 )}
                               </div>
                             </td>
@@ -637,6 +708,37 @@ export default function WeeklyPlanDetailPage() {
         </CardContent>
       </Card>
 
+      {/* Daily Activities */}
+      {!isEditing && plan.daily_activities && plan.daily_activities.length > 0 && (
+        <Card className="border-amber-300 dark:border-amber-600">
+          <CardHeader className="bg-amber-50 dark:bg-amber-950/30">
+            <CardTitle className="flex items-center gap-2 text-amber-800 dark:text-amber-200">
+              <span className="text-lg">\ud83d\udccb</span>
+              Tagesaktivit\u00e4ten
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+              {[0, 1, 2, 3, 4].map((dayIdx) => {
+                const da = plan.daily_activities?.find((a) => a.day_of_week === dayIdx);
+                if (!da || !da.content) return null;
+                return (
+                  <div key={dayIdx} className="rounded-lg border border-border p-3">
+                    <h4 className="mb-2 text-sm font-semibold">
+                      {DAY_NAMES[dayIdx as DayOfWeek]}
+                    </h4>
+                    <div
+                      className="prose prose-xs dark:prose-invert max-w-none text-sm"
+                      dangerouslySetInnerHTML={{ __html: da.content }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Entry Edit Dialog */}
       <Dialog open={entryDialog} onOpenChange={setEntryDialog}>
         <DialogContent>
@@ -751,6 +853,55 @@ export default function WeeklyPlanDetailPage() {
             </Button>
             <Button onClick={saveEntry} disabled={!editingEntry.activity}>
               {editingEntryIndex !== null ? "Aktualisieren" : "Hinzufügen"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Duplicate Entry Dialog */}
+      <Dialog open={duplicateEntryDialog} onOpenChange={setDuplicateEntryDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Eintrag duplizieren</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            {duplicateSourceEntry && (
+              <div className="rounded-lg border border-border bg-muted/30 p-3">
+                <div className="text-sm font-semibold">{duplicateSourceEntry.activity}</div>
+                <div className="text-xs text-muted-foreground">
+                  {DAY_NAMES[duplicateSourceEntry.day_of_week]} {duplicateSourceEntry.start_time} \u2013 {duplicateSourceEntry.end_time}
+                </div>
+                {duplicateSourceEntry.description && (
+                  <div className="mt-1 text-xs text-muted-foreground">{duplicateSourceEntry.description}</div>
+                )}
+              </div>
+            )}
+            <div>
+              <label className="mb-1 block text-sm font-medium">Ziel-Wochentag</label>
+              <Select value={duplicateTargetDay} onValueChange={setDuplicateTargetDay}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {days.map((d) => (
+                    <SelectItem key={d} value={String(d)}>
+                      {DAY_NAMES[d]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDuplicateEntryDialog(false)}>
+              Abbrechen
+            </Button>
+            <Button
+              onClick={handleDuplicateEntry}
+              disabled={duplicateEntryMutation.isPending}
+            >
+              <Copy className="mr-2 h-4 w-4" />
+              {duplicateEntryMutation.isPending ? "Duplizieren..." : "Duplizieren"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/weeklyplans/page.tsx
+++ b/frontend/src/app/(dashboard)/weeklyplans/page.tsx
@@ -309,7 +309,7 @@ export default function WeeklyPlansPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>KW</TableHead>
+                  <TableHead>KW / Zeitraum</TableHead>
                   <TableHead>Titel</TableHead>
                   <TableHead>Gruppe</TableHead>
                   <TableHead>Standort</TableHead>
@@ -323,7 +323,16 @@ export default function WeeklyPlansPage() {
                 {sortedPlans.map((plan) => (
                   <TableRow key={plan.id}>
                     <TableCell className="font-medium">
-                      KW {plan.calendar_week}
+                      <div>KW {plan.calendar_week}</div>
+                      {plan.week_start_date && (
+                        <div className="text-xs text-muted-foreground">
+                          {new Date(plan.week_start_date).toLocaleDateString("de-AT", { day: "2-digit", month: "2-digit" })}
+                          {" – "}
+                          {plan.week_end_date
+                            ? new Date(plan.week_end_date).toLocaleDateString("de-AT", { day: "2-digit", month: "2-digit" })
+                            : ""}
+                        </div>
+                      )}
                     </TableCell>
                     <TableCell>
                       <Link

--- a/frontend/src/hooks/use-weeklyplans.ts
+++ b/frontend/src/hooks/use-weeklyplans.ts
@@ -152,3 +152,28 @@ export function useExportPdf() {
     },
   });
 }
+
+// ── Duplicate Entry ─────────────────────────────────────────────────────────
+export function useDuplicateEntry() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      planId,
+      entryId,
+      targetDay,
+    }: {
+      planId: number;
+      entryId: number;
+      targetDay: number;
+    }) =>
+      api
+        .post(`${BASE}/${planId}/duplicate-entry/`, {
+          entry_id: entryId,
+          target_day: targetDay,
+        })
+        .then((r) => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["weeklyplans"] });
+    },
+  });
+}


### PR DESCRIPTION
## Sprint 39 Änderungen

### Issue #200: OpenAPI Enum-Warnungen beheben
- 47 Warnungen auf 0 reduziert
- Enum-Name-Overrides in SPECTACULAR_SETTINGS
- Type Hints für SerializerMethodField
- Serializer-Namenskonflikte behoben

### Issue #201: Testabdeckung weeklyplans erhöhen
- 52 neue Tests (Model + API)
- Abdeckung: CRUD, Duplizierung, Templates, PDF, RBAC

### Issue #202: KW-Datumsbereich anzeigen
- Listenseite: Datumsbereich (Mo-Fr) in KW-Spalte
- Detailseite: KW-Datumsbereich im Header

### Issue #203: Wochenthema anzeigen
- Detailseite: Styled Card für Wochenthema

### Issue #204: Tagesaktivitäten anzeigen
- Detailseite: Tagesaktivitäten-Karten pro Wochentag

### Issue #205: Zeitfenster-Zellen duplizieren
- Backend: duplicate-entry Endpunkt
- Frontend: Duplizier-Button + Dialog mit Ziel-Tag-Auswahl
- Hook: useDuplicateEntry