### PR TITLE
Sprint 46: UI-Fixes, Wochenplan-Erweiterung & Anwesenheit-Tagesprotokoll-Integration

### DIFF
--- a/backend/groups/apps.py
+++ b/backend/groups/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class GroupsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'groups'
+
+    def ready(self):
+        import groups.signals  # noqa: F401

--- a/backend/groups/serializers_attendance.py
+++ b/backend/groups/serializers_attendance.py
@@ -18,6 +18,7 @@ class AttendanceSerializer(serializers.ModelSerializer):
     status_display = serializers.CharField(
         source="get_status_display", read_only=True
     )
+    protocol_id = serializers.SerializerMethodField()
 
     class Meta:
         model = Attendance
@@ -32,6 +33,7 @@ class AttendanceSerializer(serializers.ModelSerializer):
             "recorded_by",
             "recorded_by_name",
             "student_name",
+            "protocol_id",
             "created_at",
             "updated_at",
         ]
@@ -41,6 +43,7 @@ class AttendanceSerializer(serializers.ModelSerializer):
             "recorded_by_name",
             "student_name",
             "status_display",
+            "protocol_id",
             "created_at",
             "updated_at",
         ]
@@ -54,6 +57,20 @@ class AttendanceSerializer(serializers.ModelSerializer):
         if obj.recorded_by:
             return f"{obj.recorded_by.first_name} {obj.recorded_by.last_name}".strip()
         return None
+
+    def get_protocol_id(self, obj) -> int | None:
+        """Return the DailyProtocol ID for this student/date if it exists."""
+        from groups.models_protocol import DailyProtocol
+
+        try:
+            protocol = DailyProtocol.objects.only("id").get(
+                student_id=obj.student_id,
+                date=obj.date,
+                is_deleted=False,
+            )
+            return protocol.id
+        except DailyProtocol.DoesNotExist:
+            return None
 
 
 class AttendanceCreateSerializer(serializers.ModelSerializer):

--- a/backend/groups/serializers_protocol.py
+++ b/backend/groups/serializers_protocol.py
@@ -14,6 +14,7 @@ class DailyProtocolSerializer(serializers.ModelSerializer):
     recorded_by_name = serializers.SerializerMethodField()
     school_year_name = serializers.SerializerMethodField()
     has_transfer = serializers.SerializerMethodField()
+    attendance_status = serializers.SerializerMethodField()
 
     class Meta:
         model = DailyProtocol
@@ -40,6 +41,7 @@ class DailyProtocolSerializer(serializers.ModelSerializer):
             "pickup_notes",
             "recorded_by",
             "recorded_by_name",
+            "attendance_status",
             "created_at",
             "updated_at",
         ]
@@ -77,6 +79,20 @@ class DailyProtocolSerializer(serializers.ModelSerializer):
 
     def get_has_transfer(self, obj) -> bool:
         return obj.transfer_id is not None
+
+    def get_attendance_status(self, obj) -> str:
+        """Return the attendance status for this student on this date."""
+        from groups.models_attendance import Attendance
+
+        try:
+            attendance = Attendance.objects.get(
+                student_id=obj.student_id,
+                date=obj.date,
+                is_deleted=False,
+            )
+            return attendance.status
+        except Attendance.DoesNotExist:
+            return ""
 
 
 class DailyProtocolCreateSerializer(serializers.ModelSerializer):

--- a/backend/groups/signals.py
+++ b/backend/groups/signals.py
@@ -1,0 +1,134 @@
+"""
+Signals for the groups app.
+
+Synchronises Attendance records with DailyProtocol entries so that
+marking a student as sick / absent / excused automatically creates
+or updates the corresponding daily protocol.
+"""
+
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from groups.models_attendance import Attendance
+from groups.models_protocol import DailyProtocol
+
+logger = logging.getLogger(__name__)
+
+# Status values that should trigger a DailyProtocol sync
+_SYNC_STATUSES = {
+    Attendance.Status.SICK,
+    Attendance.Status.ABSENT,
+    Attendance.Status.EXCUSED,
+}
+
+# Human-readable labels used in the auto-generated incident note
+_STATUS_LABELS = {
+    Attendance.Status.SICK: "Krank",
+    Attendance.Status.ABSENT: "Abwesend",
+    Attendance.Status.EXCUSED: "Beurlaubt",
+}
+
+_AUTO_PREFIX = "[Automatisch via Anwesenheit]"
+
+
+@receiver(post_save, sender=Attendance)
+def sync_attendance_to_protocol(sender, instance, **kwargs):
+    """
+    After saving an Attendance record, create or update the
+    corresponding DailyProtocol entry when the status indicates
+    the student is not present.
+
+    If the student is marked as *present*, any auto-generated
+    incident note is cleared (but manually written notes are kept).
+    """
+    if instance.is_deleted:
+        return
+
+    try:
+        if instance.status in _SYNC_STATUSES:
+            label = _STATUS_LABELS.get(instance.status, instance.status)
+            auto_note = f"{_AUTO_PREFIX} {label}"
+
+            protocol, created = DailyProtocol.objects.get_or_create(
+                student_id=instance.student_id,
+                date=instance.date,
+                defaults={
+                    "group_id": instance.group_id,
+                    "organization_id": instance.organization_id,
+                    "incidents": auto_note,
+                    "incident_severity": (
+                        DailyProtocol.IncidentSeverity.IMPORTANT
+                        if instance.status == Attendance.Status.SICK
+                        else DailyProtocol.IncidentSeverity.NORMAL
+                    ),
+                    "recorded_by": instance.recorded_by,
+                },
+            )
+
+            if not created:
+                # Update the existing protocol's incident note
+                # Preserve any manually written text that doesn't
+                # start with the auto-prefix.
+                existing = protocol.incidents or ""
+                # Remove old auto-note if present
+                lines = [
+                    ln
+                    for ln in existing.splitlines()
+                    if not ln.startswith(_AUTO_PREFIX)
+                ]
+                lines.insert(0, auto_note)
+                protocol.incidents = "\n".join(lines).strip()
+                protocol.incident_severity = (
+                    DailyProtocol.IncidentSeverity.IMPORTANT
+                    if instance.status == Attendance.Status.SICK
+                    else DailyProtocol.IncidentSeverity.NORMAL
+                )
+                protocol.save(
+                    update_fields=["incidents", "incident_severity", "updated_at"]
+                )
+
+            logger.info(
+                "Synced attendance → protocol for student=%s date=%s status=%s created=%s",
+                instance.student_id,
+                instance.date,
+                instance.status,
+                created,
+            )
+
+        elif instance.status == Attendance.Status.PRESENT:
+            # If student is now present, remove auto-generated note
+            try:
+                protocol = DailyProtocol.objects.get(
+                    student_id=instance.student_id,
+                    date=instance.date,
+                )
+                existing = protocol.incidents or ""
+                lines = [
+                    ln
+                    for ln in existing.splitlines()
+                    if not ln.startswith(_AUTO_PREFIX)
+                ]
+                cleaned = "\n".join(lines).strip()
+                if cleaned != existing.strip():
+                    protocol.incidents = cleaned
+                    protocol.incident_severity = (
+                        DailyProtocol.IncidentSeverity.NORMAL
+                    )
+                    protocol.save(
+                        update_fields=[
+                            "incidents",
+                            "incident_severity",
+                            "updated_at",
+                        ]
+                    )
+            except DailyProtocol.DoesNotExist:
+                pass
+
+    except Exception:
+        logger.exception(
+            "Failed to sync attendance → protocol for student=%s date=%s",
+            instance.student_id,
+            instance.date,
+        )

--- a/frontend/src/app/(dashboard)/groups/attendance/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/attendance/page.tsx
@@ -14,7 +14,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Users,
+  NotebookPen,
 } from "lucide-react";
+import Link from "next/link";
 import { PageHeader } from "@/components/common/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -34,6 +36,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/toast";
@@ -422,7 +430,24 @@ export default function AttendancePage() {
                     return (
                       <TableRow key={record.student_id}>
                         <TableCell className="font-medium">
-                          {record.student_name || `Schüler:in #${record.student_id}`}
+                          <div className="flex items-center gap-2">
+                            <span>{record.student_name || `Schüler:in #${record.student_id}`}</span>
+                            <TooltipProvider delayDuration={300}>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Link
+                                    href={`/groups/daily-protocols?student_id=${record.student_id}&date=${dateStr}`}
+                                    className="inline-flex items-center text-muted-foreground hover:text-primary transition-colors"
+                                  >
+                                    <NotebookPen className="h-4 w-4" />
+                                  </Link>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  <p>Tagesprotokoll öffnen</p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          </div>
                         </TableCell>
                         <TableCell>
                           <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/app/(dashboard)/groups/contacts/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/contacts/page.tsx
@@ -347,7 +347,7 @@ export default function ContactsPage() {
 
       {/* Create/Edit Dialog */}
       <Dialog open={formOpen} onOpenChange={setFormOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {editContact ? "Kontaktperson bearbeiten" : "Neue Kontaktperson"}
@@ -359,52 +359,57 @@ export default function ContactsPage() {
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
-            {!editContact && (
-              <div className="grid gap-2">
-                <Label>Schüler:in *</Label>
+            {/* Zeile 1: Schüler + Beziehung */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {!editContact ? (
+                <div className="grid gap-2">
+                  <Label>Schüler:in *</Label>
+                  <Select
+                    value={formData.student?.toString() ?? ""}
+                    onValueChange={(v) =>
+                      setFormData((prev) => ({ ...prev, student: Number(v) }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Schüler:in auswählen" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {students.map((s) => (
+                        <SelectItem key={s.id} value={s.id.toString()}>
+                          {s.first_name} {s.last_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+              <div className={`grid gap-2 ${editContact ? "sm:col-span-2" : ""}`}>
+                <Label>Beziehung *</Label>
                 <Select
-                  value={formData.student?.toString() ?? ""}
+                  value={formData.relationship ?? ""}
                   onValueChange={(v) =>
-                    setFormData((prev) => ({ ...prev, student: Number(v) }))
+                    setFormData((prev) => ({
+                      ...prev,
+                      relationship: v as StudentContactRelationship,
+                    }))
                   }
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Schüler:in auswählen" />
+                    <SelectValue placeholder="Beziehung auswählen" />
                   </SelectTrigger>
                   <SelectContent>
-                    {students.map((s) => (
-                      <SelectItem key={s.id} value={s.id.toString()}>
-                        {s.first_name} {s.last_name}
+                    {Object.entries(RELATIONSHIP_LABELS).map(([key, label]) => (
+                      <SelectItem key={key} value={key}>
+                        {label}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
-            )}
-            <div className="grid gap-2">
-              <Label>Beziehung *</Label>
-              <Select
-                value={formData.relationship ?? ""}
-                onValueChange={(v) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    relationship: v as StudentContactRelationship,
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Beziehung auswählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(RELATIONSHIP_LABELS).map(([key, label]) => (
-                    <SelectItem key={key} value={key}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
             </div>
-            <div className="grid grid-cols-2 gap-4">
+
+            {/* Zeile 2: Vorname + Nachname */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="grid gap-2">
                 <Label>Vorname *</Label>
                 <Input
@@ -430,54 +435,64 @@ export default function ContactsPage() {
                 />
               </div>
             </div>
-            <div className="grid gap-2">
-              <Label>Telefon</Label>
-              <Input
-                type="tel"
-                value={formData.phone ?? ""}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, phone: e.target.value }))
-                }
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label>E-Mail</Label>
-              <Input
-                type="email"
-                value={formData.email ?? ""}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, email: e.target.value }))
-                }
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label>WhatsApp verfügbar</Label>
-                <p className="text-sm text-muted-foreground">
-                  Kann über WhatsApp kontaktiert werden
-                </p>
+
+            {/* Zeile 3: Telefon + E-Mail */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <Label>Telefon</Label>
+                <Input
+                  type="tel"
+                  value={formData.phone ?? ""}
+                  onChange={(e) =>
+                    setFormData((prev) => ({ ...prev, phone: e.target.value }))
+                  }
+                />
               </div>
-              <Switch
-                checked={formData.whatsapp_available ?? false}
-                onCheckedChange={(v) =>
-                  setFormData((prev) => ({ ...prev, whatsapp_available: v }))
-                }
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label>Hauptansprechperson</Label>
-                <p className="text-sm text-muted-foreground">
-                  Als primäre Kontaktperson markieren
-                </p>
+              <div className="grid gap-2">
+                <Label>E-Mail</Label>
+                <Input
+                  type="email"
+                  value={formData.email ?? ""}
+                  onChange={(e) =>
+                    setFormData((prev) => ({ ...prev, email: e.target.value }))
+                  }
+                />
               </div>
-              <Switch
-                checked={formData.is_primary ?? false}
-                onCheckedChange={(v) =>
-                  setFormData((prev) => ({ ...prev, is_primary: v }))
-                }
-              />
             </div>
+
+            {/* Zeile 4: Switches nebeneinander */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex items-center justify-between rounded-lg border p-3">
+                <div className="space-y-0.5">
+                  <Label>WhatsApp verfügbar</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Über WhatsApp erreichbar
+                  </p>
+                </div>
+                <Switch
+                  checked={formData.whatsapp_available ?? false}
+                  onCheckedChange={(v) =>
+                    setFormData((prev) => ({ ...prev, whatsapp_available: v }))
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between rounded-lg border p-3">
+                <div className="space-y-0.5">
+                  <Label>Hauptansprechperson</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Primäre Kontaktperson
+                  </p>
+                </div>
+                <Switch
+                  checked={formData.is_primary ?? false}
+                  onCheckedChange={(v) =>
+                    setFormData((prev) => ({ ...prev, is_primary: v }))
+                  }
+                />
+              </div>
+            </div>
+
+            {/* Zeile 5: Notizen (volle Breite) */}
             <div className="grid gap-2">
               <Label>Notizen</Label>
               <Textarea
@@ -486,6 +501,7 @@ export default function ContactsPage() {
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, notes: e.target.value }))
                 }
+                rows={3}
               />
             </div>
           </div>

--- a/frontend/src/app/(dashboard)/groups/daily-protocols/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/daily-protocols/page.tsx
@@ -63,6 +63,9 @@ import {
   Clock,
   User,
   Download,
+  ThermometerSun,
+  XCircle,
+  CalendarOff,
 } from "lucide-react";
 import { ExportButtons } from "@/components/common/export-buttons";
 import { Pagination } from "@/components/common/pagination";
@@ -71,8 +74,31 @@ import type {
   IncidentSeverity,
   BulkDailyProtocolRecord,
   StudentContact,
+  AttendanceStatus,
 } from "@/types/models";
 import { SEVERITY_LABELS, SEVERITY_COLORS } from "@/types/models";
+
+/* ─── Attendance Status Badge ──────────────────────────────────────── */
+
+const ATTENDANCE_CONFIG: Record<string, { label: string; icon: typeof CheckCircle2; variant: "success" | "destructive" | "warning" | "secondary" }> = {
+  present: { label: "Anwesend", icon: CheckCircle2, variant: "success" },
+  absent: { label: "Abwesend", icon: XCircle, variant: "destructive" },
+  sick: { label: "Krank", icon: ThermometerSun, variant: "warning" },
+  excused: { label: "Beurlaubt", icon: CalendarOff, variant: "secondary" },
+};
+
+function AttendanceBadge({ status }: { status: AttendanceStatus | "" }) {
+  if (!status) return null;
+  const config = ATTENDANCE_CONFIG[status];
+  if (!config) return null;
+  const Icon = config.icon;
+  return (
+    <Badge variant={config.variant} className="gap-1 text-xs">
+      <Icon className="h-3 w-3" />
+      {config.label}
+    </Badge>
+  );
+}
 
 /* ─── Helper ─────────────────────────────────────────────────────────── */
 
@@ -114,6 +140,7 @@ interface ProtocolRow {
   picked_up_by_id: number | null;
   pickup_notes: string;
   existing_id?: number;
+  attendance_status?: AttendanceStatus | "";
 }
 
 /* ─── Main Page ──────────────────────────────────────────────────────── */
@@ -237,6 +264,7 @@ export default function DailyProtocolsPage() {
         picked_up_by_id: existing?.picked_up_by ?? null,
         pickup_notes: existing?.pickup_notes ?? "",
         existing_id: existing?.id,
+        attendance_status: existing?.attendance_status ?? "",
       };
     });
     setRows(newRows);
@@ -491,6 +519,9 @@ export default function DailyProtocolsPage() {
                             Bereits erfasst
                           </Badge>
                         )}
+                        {row.attendance_status && (
+                          <AttendanceBadge status={row.attendance_status} />
+                        )}
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
                         {/* Ankunft */}
@@ -717,7 +748,12 @@ export default function DailyProtocolsPage() {
                       {listData.results.map((p: DailyProtocol) => (
                         <TableRow key={p.id}>
                           <TableCell>
-                            <div className="font-medium">{p.student_name}</div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">{p.student_name}</span>
+                              {p.attendance_status && (
+                                <AttendanceBadge status={p.attendance_status} />
+                              )}
+                            </div>
                             {p.has_transfer && (
                               <div className="flex items-center gap-1 text-xs text-amber-500 mt-0.5">
                                 <ArrowLeftRight className="h-3 w-3" />

--- a/frontend/src/app/(dashboard)/weeklyplans/page.tsx
+++ b/frontend/src/app/(dashboard)/weeklyplans/page.tsx
@@ -330,6 +330,7 @@ export default function WeeklyPlansPage() {
                 <TableRow>
                   <TableHead>KW / Zeitraum</TableHead>
                   <TableHead>Titel</TableHead>
+                  <TableHead>Schuljahr</TableHead>
                   <TableHead>Gruppe</TableHead>
                   <TableHead>Standort</TableHead>
                   <TableHead>Status</TableHead>
@@ -360,6 +361,9 @@ export default function WeeklyPlansPage() {
                       >
                         {plan.title}
                       </Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {plan.school_year_name || "–"}
                     </TableCell>
                     <TableCell>{plan.group_name}</TableCell>
                     <TableCell>{plan.location_name}</TableCell>

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -576,6 +576,7 @@ export interface Attendance {
   recorded_by: number | null;
   recorded_by_name: string | null;
   student_name: string;
+  protocol_id: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -733,6 +734,7 @@ export interface DailyProtocol {
   pickup_notes: string;
   recorded_by: number | null;
   recorded_by_name: string;
+  attendance_status: AttendanceStatus | "";
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Sprint 46 - Zusammenfassung

### Kontaktperson-Modal Layout-Fix (#236)
- Modal-Breite von max-w-lg auf max-w-3xl erhöht
- 2-Spalten-Layout für Formularfelder
- Scrollbar bei kleinen Viewports

### Wochenplan-Tabelle Schuljahr (#237)
- Neue Spalte 'Schuljahr' in der Wochenplan-Übersicht
- Daten aus bestehendem school_year_name Feld

### Anwesenheit-Tagesprotokoll-Integration (#238)
- Django post_save Signal: Attendance → DailyProtocol Sync
- attendance_status im DailyProtocol-Serializer
- protocol_id im Attendance-Serializer
- Anwesenheits-Badge im Tagesprotokoll (Erfassung + Liste)
- Tagesprotokoll-Link in Anwesenheits-Tabelle

Closes #236 #237 #238