### PR TITLE
Sprint 52: Security Hardening - JWT httpOnly Cookies & Valkey Setup

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -240,8 +240,8 @@ AUTH_USER_MODEL = "core.User"
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
+        "core.authentication.CookieJWTAuthentication",
         "core.authentication.QueryParameterJWTAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": (
         "rest_framework.permissions.IsAuthenticated",

--- a/backend/core/authentication.py
+++ b/backend/core/authentication.py
@@ -1,13 +1,47 @@
 """
 Custom JWT Authentication backends.
 
-Includes a query-parameter based authentication for file downloads,
-where the browser opens a new window/tab and cannot send Authorization headers.
+Includes:
+- CookieJWTAuthentication: Reads JWT from httpOnly cookies (primary)
+- QueryParameterJWTAuthentication: Reads JWT from query params (file downloads)
+
+The authentication order is:
+1. Standard Authorization header (Bearer token) – for API clients
+2. httpOnly cookie (access_token) – for browser sessions
+3. Query parameter (?token=...) – for file downloads via window.open()
 """
 
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.tokens import AccessToken
+
+from core.cookie_utils import ACCESS_TOKEN_COOKIE
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    JWT Authentication that reads the access token from an httpOnly cookie.
+
+    Falls back to the standard Authorization header if no cookie is present,
+    ensuring backward compatibility with API clients and mobile apps.
+    """
+
+    def authenticate(self, request):
+        # First try standard header-based authentication (Authorization: Bearer ...)
+        header_result = super().authenticate(request)
+        if header_result is not None:
+            return header_result
+
+        # Fall back to httpOnly cookie
+        raw_token = request.COOKIES.get(ACCESS_TOKEN_COOKIE)
+        if raw_token is None:
+            return None
+
+        try:
+            validated_token = self.get_validated_token(raw_token)
+            return self.get_user(validated_token), validated_token
+        except (InvalidToken, TokenError):
+            return None
 
 
 class QueryParameterJWTAuthentication(JWTAuthentication):
@@ -15,7 +49,7 @@ class QueryParameterJWTAuthentication(JWTAuthentication):
     JWT Authentication that also accepts the token via query parameter.
 
     This is needed for file downloads (PDF, XLSX) where the browser
-    opens a direct URL via window.open() and cannot send Authorization headers.
+    opens a new window/tab and cannot send Authorization headers or cookies.
 
     Usage:
         GET /api/v1/weeklyplans/123/pdf/?token=<jwt_access_token>
@@ -26,6 +60,15 @@ class QueryParameterJWTAuthentication(JWTAuthentication):
         header_result = super().authenticate(request)
         if header_result is not None:
             return header_result
+
+        # Then try cookie-based authentication
+        cookie_token = request.COOKIES.get(ACCESS_TOKEN_COOKIE)
+        if cookie_token:
+            try:
+                validated_token = self.get_validated_token(cookie_token)
+                return self.get_user(validated_token), validated_token
+            except (InvalidToken, TokenError):
+                pass
 
         # Fall back to query parameter
         raw_token = request.query_params.get("token")

--- a/backend/core/cookie_utils.py
+++ b/backend/core/cookie_utils.py
@@ -1,0 +1,93 @@
+"""
+Utility functions for JWT httpOnly cookie management.
+
+Provides consistent cookie setting and clearing for access and refresh tokens.
+Cookies are httpOnly, Secure (in production), and SameSite=Lax to prevent
+XSS and CSRF attacks while allowing same-site navigation.
+"""
+
+from django.conf import settings
+from rest_framework.response import Response
+
+
+# Cookie names
+ACCESS_TOKEN_COOKIE = "access_token"
+REFRESH_TOKEN_COOKIE = "refresh_token"
+
+
+def _get_cookie_defaults() -> dict:
+    """Return default cookie attributes based on environment."""
+    is_production = not settings.DEBUG
+    return {
+        "httponly": True,
+        "secure": is_production,
+        "samesite": "Lax",
+        "path": "/",
+        # Domain is not set explicitly – the browser will scope it
+        # to the exact domain that set the cookie.
+    }
+
+
+def set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: str,
+) -> Response:
+    """
+    Set httpOnly cookies for both access and refresh JWT tokens.
+
+    Args:
+        response: The DRF Response object to attach cookies to.
+        access_token: The JWT access token string.
+        refresh_token: The JWT refresh token string.
+
+    Returns:
+        The response with cookies attached.
+    """
+    defaults = _get_cookie_defaults()
+
+    # Access token cookie – shorter max_age matching JWT lifetime
+    access_max_age = int(
+        settings.SIMPLE_JWT.get("ACCESS_TOKEN_LIFETIME").total_seconds()
+    )
+    response.set_cookie(
+        key=ACCESS_TOKEN_COOKIE,
+        value=access_token,
+        max_age=access_max_age,
+        **defaults,
+    )
+
+    # Refresh token cookie – longer max_age matching JWT lifetime
+    refresh_max_age = int(
+        settings.SIMPLE_JWT.get("REFRESH_TOKEN_LIFETIME").total_seconds()
+    )
+    response.set_cookie(
+        key=REFRESH_TOKEN_COOKIE,
+        value=refresh_token,
+        max_age=refresh_max_age,
+        **defaults,
+    )
+
+    return response
+
+
+def clear_auth_cookies(response: Response) -> Response:
+    """
+    Clear both access and refresh token cookies.
+
+    Args:
+        response: The DRF Response object to clear cookies from.
+
+    Returns:
+        The response with cookies cleared.
+    """
+    defaults = _get_cookie_defaults()
+    # Remove httponly from kwargs for delete_cookie (not supported)
+    delete_kwargs = {
+        k: v for k, v in defaults.items() if k != "httponly"
+    }
+
+    response.delete_cookie(ACCESS_TOKEN_COOKIE, **delete_kwargs)
+    response.delete_cookie(REFRESH_TOKEN_COOKIE, **delete_kwargs)
+
+    return response

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -3,6 +3,9 @@ Views for authentication and user profile endpoints.
 
 Provides login, logout, token refresh, password reset/change,
 and user profile management.
+
+JWT tokens are stored in httpOnly cookies for browser security.
+The Authorization header is still supported for API clients.
 """
 
 from django.conf import settings
@@ -11,8 +14,14 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
-from rest_framework_simplejwt.views import TokenRefreshView
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
 
+from core.cookie_utils import (
+    REFRESH_TOKEN_COOKIE,
+    clear_auth_cookies,
+    set_auth_cookies,
+)
 from core.middleware import ensure_tenant_context
 from core.serializers import (
     LoginSerializer,
@@ -30,7 +39,7 @@ class LoginView(APIView):
     POST /api/v1/auth/login/
 
     Authenticate a user with username/email and password.
-    Returns JWT access and refresh tokens along with user data.
+    Returns user data and sets JWT tokens as httpOnly cookies.
     Rate limited to 5 attempts per minute to prevent brute-force attacks.
     """
 
@@ -42,7 +51,7 @@ class LoginView(APIView):
     @extend_schema(
         tags=["Auth"],
         summary="Benutzer anmelden",
-        description="Authentifizierung mit Benutzername/E-Mail und Passwort. Gibt JWT-Tokens zurück.",
+        description="Authentifizierung mit Benutzername/E-Mail und Passwort. Setzt JWT-Tokens als httpOnly-Cookies.",
         request=LoginSerializer,
         responses={
             200: OpenApiResponse(description="Login erfolgreich"),
@@ -53,53 +62,132 @@ class LoginView(APIView):
         serializer = LoginSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         data = serializer.save()
-        return Response(data, status=status.HTTP_200_OK)
+
+        # If 2FA is required, return partial response without tokens
+        if data.get("requires_2fa"):
+            return Response(data, status=status.HTTP_200_OK)
+
+        # Extract tokens from response data and set as cookies
+        access_token = data.pop("access", None)
+        refresh_token = data.pop("refresh", None)
+
+        response = Response(data, status=status.HTTP_200_OK)
+
+        if access_token and refresh_token:
+            set_auth_cookies(response, access_token, refresh_token)
+
+        return response
 
 
 class LogoutView(APIView):
     """
     POST /api/v1/auth/logout/
 
-    Logout the user by blacklisting the refresh token.
+    Logout the user by blacklisting the refresh token and clearing cookies.
+    Reads the refresh token from the httpOnly cookie or request body.
     """
 
     permission_classes = [permissions.IsAuthenticated]
-    serializer_class = LogoutSerializer
 
     @extend_schema(
         tags=["Auth"],
         summary="Benutzer abmelden",
-        description="Blacklistet den Refresh Token und meldet den Benutzer ab.",
-        request=LogoutSerializer,
+        description="Blacklistet den Refresh Token und löscht die Auth-Cookies.",
         responses={
             200: OpenApiResponse(description="Logout erfolgreich"),
             400: OpenApiResponse(description="Ungültiger Token"),
         },
     )
     def post(self, request):
-        serializer = LogoutSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-        return Response(
+        # Try to get refresh token from cookie first, then from body
+        refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
+        if not refresh_token:
+            refresh_token = request.data.get("refresh")
+
+        if refresh_token:
+            try:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+            except Exception:
+                pass  # Token may already be blacklisted or invalid
+
+        response = Response(
             {"detail": "Erfolgreich abgemeldet."},
             status=status.HTTP_200_OK,
         )
+        clear_auth_cookies(response)
+        return response
 
 
-class CustomTokenRefreshView(TokenRefreshView):
+class CustomTokenRefreshView(APIView):
     """
     POST /api/v1/auth/refresh/
 
-    Refresh the JWT access token using a valid refresh token.
+    Refresh the JWT access token using the refresh token from the httpOnly cookie.
+    Sets new tokens as httpOnly cookies.
     """
+
+    permission_classes = [permissions.AllowAny]
 
     @extend_schema(
         tags=["Auth"],
         summary="Token erneuern",
-        description="Erneuert den Access Token mit einem gültigen Refresh Token.",
+        description="Erneuert den Access Token mit dem Refresh Token aus dem httpOnly-Cookie.",
+        responses={
+            200: OpenApiResponse(description="Token erfolgreich erneuert"),
+            401: OpenApiResponse(description="Ungültiger oder abgelaufener Refresh Token"),
+        },
     )
-    def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
+    def post(self, request):
+        # Try to get refresh token from cookie first, then from body
+        refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
+        if not refresh_token:
+            refresh_token = request.data.get("refresh")
+
+        if not refresh_token:
+            return Response(
+                {"detail": "Kein Refresh Token vorhanden."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            old_token = RefreshToken(refresh_token)
+
+            # Rotate: create new refresh token and blacklist old one
+            if settings.SIMPLE_JWT.get("ROTATE_REFRESH_TOKENS", False):
+                new_refresh = RefreshToken.for_user(old_token.payload.get("user_id"))
+                # Get user from old token to generate proper new token
+                from core.models import User
+                user_id = old_token.payload.get("user_id")
+                user = User.objects.get(pk=user_id)
+                new_refresh = RefreshToken.for_user(user)
+
+                if settings.SIMPLE_JWT.get("BLACKLIST_AFTER_ROTATION", False):
+                    try:
+                        old_token.blacklist()
+                    except Exception:
+                        pass
+
+                new_access = str(new_refresh.access_token)
+                new_refresh_str = str(new_refresh)
+            else:
+                new_access = str(old_token.access_token)
+                new_refresh_str = str(old_token)
+
+            response = Response(
+                {"detail": "Token erfolgreich erneuert."},
+                status=status.HTTP_200_OK,
+            )
+            set_auth_cookies(response, new_access, new_refresh_str)
+            return response
+
+        except (InvalidToken, TokenError) as e:
+            response = Response(
+                {"detail": "Ungültiger oder abgelaufener Refresh Token."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+            clear_auth_cookies(response)
+            return response
 
 
 class MeView(APIView):
@@ -346,4 +434,3 @@ class PasswordChangeView(APIView):
             {"detail": "Passwort wurde erfolgreich geändert."},
             status=status.HTTP_200_OK,
         )
-

--- a/backend/core/views_2fa.py
+++ b/backend/core/views_2fa.py
@@ -19,6 +19,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 
+from core.cookie_utils import set_auth_cookies
+
 
 class TwoFactorSetupSerializer(serializers.Serializer):
     """Response serializer for 2FA setup."""
@@ -283,10 +285,8 @@ class TwoFactorLoginVerifyView(APIView):
         user.last_login = timezone.now()
         user.save(update_fields=["last_login"])
 
-        return Response(
+        response = Response(
             {
-                "access": str(refresh.access_token),
-                "refresh": str(refresh),
                 "user": {
                     "id": user.id,
                     "username": user.username,
@@ -299,6 +299,8 @@ class TwoFactorLoginVerifyView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+        set_auth_cookies(response, str(refresh.access_token), str(refresh))
+        return response
 
 
 class TwoFactorStatusView(APIView):

--- a/frontend/src/components/auth-provider.tsx
+++ b/frontend/src/components/auth-provider.tsx
@@ -25,10 +25,11 @@ interface AuthContextType {
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 /**
- * Set a simple cookie to signal authentication status to the middleware.
+ * Set a simple cookie to signal authentication status to the Next.js middleware.
  *
- * Uses Secure flag on HTTPS to ensure the cookie is sent with server requests.
- * Uses SameSite=Lax for CSRF protection while allowing normal navigation.
+ * This is a non-httpOnly cookie that the middleware can read to decide
+ * whether to redirect to /login. The actual JWT tokens are stored in
+ * httpOnly cookies managed by the backend.
  */
 function setAuthCookie(authenticated: boolean) {
   if (typeof document === "undefined") return;
@@ -48,22 +49,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   /**
    * Check if the user is authenticated on mount.
+   *
+   * Since JWT tokens are now in httpOnly cookies (not accessible via JS),
+   * we check auth status by calling the /auth/me/ endpoint.
+   * If the cookie is valid, the backend returns the user profile.
    */
   const checkAuth = useCallback(async () => {
-    const token = localStorage.getItem("access_token");
-    if (!token) {
-      setAuthCookie(false);
-      setIsLoading(false);
-      return;
-    }
-
     try {
       const profile = await authApi.getProfile();
       setUser(profile);
       setAuthCookie(true);
     } catch {
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("refresh_token");
       setAuthCookie(false);
       setUser(null);
     } finally {
@@ -76,40 +72,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [checkAuth]);
 
   /**
-   * Login with credentials and store tokens.
+   * Login with credentials.
+   * The backend sets httpOnly cookies in the response.
    * Returns the response so the caller can check requires_2fa.
    */
   const login = useCallback(
     async (credentials: LoginCredentials): Promise<LoginResponse> => {
-      // Clear any stale tokens before attempting login to prevent
-      // the request interceptor from attaching an expired token
-      // that could interfere with the login flow.
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("refresh_token");
-
       const response = await authApi.login(credentials);
 
-      // If 2FA is required, don't store tokens yet – return response for 2FA page
+      // If 2FA is required, don't set auth state yet
       if (response.requires_2fa) {
         return response;
       }
 
-      // Standard login without 2FA
-      if (response.access && response.refresh) {
-        localStorage.setItem("access_token", response.access);
-        localStorage.setItem("refresh_token", response.refresh);
-        setAuthCookie(true);
+      // Standard login without 2FA – cookies are already set by the backend
+      setAuthCookie(true);
 
-        // Fetch full profile after login
-        const profile = await authApi.getProfile();
-        setUser(profile);
+      // Fetch full profile after login
+      const profile = await authApi.getProfile();
+      setUser(profile);
 
-        // Use window.location for a full page navigation to ensure
-        // the middleware sees the newly set cookie on the server request.
-        // router.push() uses client-side navigation which may not trigger
-        // a fresh server request with the updated cookies.
-        window.location.href = "/";
-      }
+      // Use window.location for a full page navigation to ensure
+      // the middleware sees the newly set cookie on the server request.
+      window.location.href = "/";
 
       return response;
     },
@@ -118,41 +103,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   /**
    * Complete login with 2FA verification.
+   * The backend sets httpOnly cookies in the response.
    */
   const loginWith2FA = useCallback(
     async (userId: number, code: string) => {
-      const response = await authApi.verify2FALogin({ user_id: userId, code });
+      await authApi.verify2FALogin({ user_id: userId, code });
 
-      if (response.access && response.refresh) {
-        localStorage.setItem("access_token", response.access);
-        localStorage.setItem("refresh_token", response.refresh);
-        setAuthCookie(true);
+      // Cookies are set by the backend response
+      setAuthCookie(true);
 
-        // Fetch full profile after login
-        const profile = await authApi.getProfile();
-        setUser(profile);
+      // Fetch full profile after login
+      const profile = await authApi.getProfile();
+      setUser(profile);
 
-        // Use window.location for a full page navigation (see login above)
-        window.location.href = "/";
-      }
+      // Use window.location for a full page navigation
+      window.location.href = "/";
     },
     [],
   );
 
   /**
-   * Logout and clear tokens.
+   * Logout: call backend to blacklist refresh token and clear cookies.
    */
   const logout = useCallback(async () => {
-    const refreshToken = localStorage.getItem("refresh_token");
     try {
-      if (refreshToken) {
-        await authApi.logout(refreshToken);
-      }
+      await authApi.logout();
     } catch {
       // Ignore errors during logout
     } finally {
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("refresh_token");
       setAuthCookie(false);
       setUser(null);
       router.push("/login");

--- a/frontend/src/components/session-timeout-wrapper.tsx
+++ b/frontend/src/components/session-timeout-wrapper.tsx
@@ -7,8 +7,12 @@ import { useSessionTimeout } from "@/hooks/use-session-timeout";
 import { SessionTimeoutDialog } from "@/components/session-timeout-dialog";
 
 /**
- * Wrapper component that monitors JWT token expiry and shows
- * a warning dialog 2 minutes before the session expires.
+ * Wrapper component that monitors session activity and shows
+ * a warning dialog before the session expires.
+ *
+ * Since JWT tokens are now in httpOnly cookies (not accessible via JS),
+ * the timeout is based on a configurable session duration rather than
+ * parsing the JWT expiry directly.
  *
  * Place this inside the dashboard layout (within AuthProvider).
  */
@@ -16,21 +20,11 @@ export function SessionTimeoutWrapper() {
   const { logout, isAuthenticated } = useAuth();
 
   /**
-   * Extend the session by refreshing the JWT token.
+   * Extend the session by refreshing the JWT token via the cookie-based endpoint.
    */
   const handleExtendSession = useCallback(async () => {
-    const refreshToken = localStorage.getItem("refresh_token");
-    if (!refreshToken) {
-      await logout();
-      return;
-    }
-
     try {
-      const data = await authApi.refreshToken(refreshToken);
-      localStorage.setItem("access_token", data.access);
-      if (data.refresh) {
-        localStorage.setItem("refresh_token", data.refresh);
-      }
+      await authApi.refreshToken();
     } catch {
       await logout();
     }

--- a/frontend/src/hooks/use-session-timeout.ts
+++ b/frontend/src/hooks/use-session-timeout.ts
@@ -3,29 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
- * JWT token payload interface (minimal, only what we need).
- */
-interface JWTPayload {
-  exp: number;
-  iat: number;
-}
-
-/**
- * Parse a JWT token without a library.
- * Only decodes the payload – does NOT verify the signature.
- */
-function parseJWT(token: string): JWTPayload | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(atob(parts[1]));
-    return payload as JWTPayload;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Configuration for the session timeout warning.
  */
 interface UseSessionTimeoutOptions {
@@ -38,14 +15,23 @@ interface UseSessionTimeoutOptions {
 }
 
 /**
- * Hook that monitors the JWT access token expiry and shows a warning dialog
- * before the token expires. Provides state and actions for a timeout dialog.
+ * Session duration in seconds.
+ *
+ * Since JWT tokens are now in httpOnly cookies and cannot be parsed client-side,
+ * we use a fixed session duration that matches the backend ACCESS_TOKEN_LIFETIME.
+ * The backend default is 60 minutes.
+ */
+const SESSION_DURATION_SECONDS = 60 * 60; // 60 minutes
+
+/**
+ * Hook that monitors user activity and shows a warning dialog
+ * before the session expires. Provides state and actions for a timeout dialog.
  *
  * The hook:
- * 1. Reads the access_token from localStorage
- * 2. Parses the JWT to get the `exp` claim
- * 3. Sets a timer to show a warning dialog N seconds before expiry
- * 4. Sets a timer to auto-logout when the token expires
+ * 1. Tracks the last user activity timestamp
+ * 2. Sets a timer to show a warning dialog N seconds before session expiry
+ * 3. Sets a timer to auto-logout when the session expires
+ * 4. Resets timers on user activity (mouse, keyboard, touch)
  * 5. Provides `showWarning`, `remainingSeconds`, `extendSession`, `dismiss`
  */
 export function useSessionTimeout({
@@ -59,6 +45,7 @@ export function useSessionTimeout({
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isExtendingRef = useRef(false);
+  const lastActivityRef = useRef<number>(Date.now());
 
   /**
    * Clear all timers.
@@ -79,31 +66,24 @@ export function useSessionTimeout({
   }, []);
 
   /**
-   * Schedule warning and expiry timers based on the current access token.
+   * Schedule warning and expiry timers based on last activity.
    */
   const scheduleTimers = useCallback(() => {
     clearAllTimers();
 
     if (typeof window === "undefined") return;
 
-    const token = localStorage.getItem("access_token");
-    if (!token) return;
+    const now = Date.now();
+    lastActivityRef.current = now;
 
-    const payload = parseJWT(token);
-    if (!payload?.exp) return;
+    const sessionExpiresAt = now + SESSION_DURATION_SECONDS * 1000;
+    const warningAt = sessionExpiresAt - warningBeforeExpiry * 1000;
 
-    const now = Math.floor(Date.now() / 1000);
-    const secondsUntilExpiry = payload.exp - now;
-
-    // Token already expired
-    if (secondsUntilExpiry <= 0) {
-      onSessionExpired();
-      return;
-    }
+    const msUntilWarning = warningAt - now;
+    const msUntilExpiry = sessionExpiresAt - now;
 
     // Schedule warning dialog
-    const secondsUntilWarning = secondsUntilExpiry - warningBeforeExpiry;
-    if (secondsUntilWarning > 0) {
+    if (msUntilWarning > 0) {
       warningTimerRef.current = setTimeout(() => {
         setShowWarning(true);
         setRemainingSeconds(warningBeforeExpiry);
@@ -118,21 +98,7 @@ export function useSessionTimeout({
             return prev - 1;
           });
         }, 1000);
-      }, secondsUntilWarning * 1000);
-    } else {
-      // Already within warning window
-      setShowWarning(true);
-      setRemainingSeconds(Math.max(0, secondsUntilExpiry));
-
-      countdownRef.current = setInterval(() => {
-        setRemainingSeconds((prev) => {
-          if (prev <= 1) {
-            if (countdownRef.current) clearInterval(countdownRef.current);
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
+      }, msUntilWarning);
     }
 
     // Schedule auto-logout
@@ -142,7 +108,7 @@ export function useSessionTimeout({
       if (!isExtendingRef.current) {
         onSessionExpired();
       }
-    }, secondsUntilExpiry * 1000);
+    }, msUntilExpiry);
   }, [clearAllTimers, warningBeforeExpiry, onSessionExpired]);
 
   /**
@@ -153,7 +119,7 @@ export function useSessionTimeout({
     try {
       await onExtendSession();
       setShowWarning(false);
-      // Re-schedule timers with the new token
+      // Re-schedule timers with fresh session
       scheduleTimers();
     } catch {
       onSessionExpired();
@@ -169,21 +135,12 @@ export function useSessionTimeout({
     setShowWarning(false);
   }, []);
 
-  // Schedule timers on mount and when token changes
+  // Schedule timers on mount
   useEffect(() => {
     scheduleTimers();
 
-    // Listen for storage events (token refresh from another tab)
-    const handleStorage = (e: StorageEvent) => {
-      if (e.key === "access_token") {
-        scheduleTimers();
-      }
-    };
-    window.addEventListener("storage", handleStorage);
-
     return () => {
       clearAllTimers();
-      window.removeEventListener("storage", handleStorage);
     };
   }, [scheduleTimers, clearAllTimers]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,7 +3,12 @@ import axios from "axios";
 /**
  * Pre-configured Axios instance for communicating with the Django backend.
  *
- * Includes automatic JWT token attachment and silent token refresh on 401.
+ * Authentication is handled via httpOnly cookies set by the backend.
+ * The `withCredentials: true` flag ensures cookies are sent with every request.
+ * No manual token management is needed on the client side.
+ *
+ * Token refresh is handled automatically on 401 responses by calling
+ * the /auth/refresh/ endpoint (which reads the refresh token from its cookie).
  */
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "/api/v1",
@@ -13,33 +18,19 @@ const api = axios.create({
   withCredentials: true,
 });
 
-// Request interceptor: attach JWT access token
-api.interceptors.request.use(
-  (config) => {
-    if (typeof window !== "undefined") {
-      const token = localStorage.getItem("access_token");
-      if (token && config.headers) {
-        config.headers.Authorization = `Bearer ${token}`;
-      }
-    }
-    return config;
-  },
-  (error) => Promise.reject(error),
-);
-
-// Response interceptor: handle 401 with silent token refresh
+// Response interceptor: handle 401 with silent token refresh via cookies
 let isRefreshing = false;
 let failedQueue: Array<{
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
 }> = [];
 
-const processQueue = (error: unknown, token: string | null = null) => {
+const processQueue = (error: unknown) => {
   failedQueue.forEach((prom) => {
     if (error) {
       prom.reject(error);
     } else {
-      prom.resolve(token);
+      prom.resolve(undefined);
     }
   });
   failedQueue = [];
@@ -62,8 +53,8 @@ api.interceptors.response.use(
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
         })
-          .then((token) => {
-            originalRequest.headers.Authorization = `Bearer ${token}`;
+          .then(() => {
+            // Retry with cookies (no manual header needed)
             return api(originalRequest);
           })
           .catch((err) => Promise.reject(err));
@@ -72,34 +63,21 @@ api.interceptors.response.use(
       originalRequest._retry = true;
       isRefreshing = true;
 
-      const refreshToken = localStorage.getItem("refresh_token");
-
-      if (!refreshToken) {
-        isRefreshing = false;
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
-        window.location.href = "/login";
-        return Promise.reject(error);
-      }
-
       try {
-        const { data } = await axios.post(
+        // Call refresh endpoint – it reads the refresh token from the httpOnly cookie
+        // and sets new access + refresh cookies in the response
+        await axios.post(
           `${api.defaults.baseURL}/auth/refresh/`,
-          { refresh: refreshToken },
+          {},
+          { withCredentials: true },
         );
 
-        localStorage.setItem("access_token", data.access);
-        if (data.refresh) {
-          localStorage.setItem("refresh_token", data.refresh);
-        }
-
-        processQueue(null, data.access);
-        originalRequest.headers.Authorization = `Bearer ${data.access}`;
+        processQueue(null);
+        // Retry original request – new cookies are automatically included
         return api(originalRequest);
       } catch (refreshError) {
-        processQueue(refreshError, null);
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
+        processQueue(refreshError);
+        // Refresh failed – redirect to login
         window.location.href = "/login";
         return Promise.reject(refreshError);
       } finally {

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,5 +1,8 @@
 /**
  * Auth API service – handles all authentication-related API calls.
+ *
+ * JWT tokens are managed via httpOnly cookies set by the backend.
+ * No manual token handling is needed on the client side.
  */
 
 import api from "@/lib/api";
@@ -9,7 +12,6 @@ import type {
   PasswordChange,
   PasswordResetConfirm,
   PasswordResetRequest,
-  TokenRefreshResponse,
   TwoFactorLoginVerify,
   TwoFactorSetupResponse,
   TwoFactorStatusResponse,
@@ -20,6 +22,7 @@ import type {
 export const authApi = {
   /**
    * Login with username/email and password.
+   * The backend sets httpOnly cookies with JWT tokens in the response.
    * May return requires_2fa=true if 2FA is enabled.
    */
   login: async (credentials: LoginCredentials): Promise<LoginResponse> => {
@@ -28,22 +31,20 @@ export const authApi = {
   },
 
   /**
-   * Logout by blacklisting the refresh token.
+   * Logout by calling the backend which blacklists the refresh token
+   * and clears the httpOnly cookies.
    */
-  logout: async (refreshToken: string): Promise<void> => {
-    await api.post("/auth/logout/", { refresh: refreshToken });
+  logout: async (): Promise<void> => {
+    await api.post("/auth/logout/");
   },
 
   /**
    * Refresh the access token.
+   * The backend reads the refresh token from the httpOnly cookie
+   * and sets new tokens as cookies in the response.
    */
-  refreshToken: async (
-    refreshToken: string,
-  ): Promise<TokenRefreshResponse> => {
-    const { data } = await api.post<TokenRefreshResponse>("/auth/refresh/", {
-      refresh: refreshToken,
-    });
-    return data;
+  refreshToken: async (): Promise<void> => {
+    await api.post("/auth/refresh/");
   },
 
   /**
@@ -113,7 +114,7 @@ export const authApi = {
 
   /**
    * Verify 2FA during login process.
-   * Returns JWT tokens upon successful verification.
+   * The backend sets httpOnly cookies with JWT tokens in the response.
    */
   verify2FALogin: async (payload: TwoFactorLoginVerify): Promise<LoginResponse> => {
     const { data } = await api.post<LoginResponse>("/auth/2fa/login-verify/", payload);

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,14 +1,17 @@
 /**
  * Generische Export-Funktionen fuer XLSX und PDF Downloads.
  *
- * Nutzt direkte URL-Navigation (window.open) statt Blob-Downloads,
- * damit der Browser den Download nativ handhabt.
- * Der JWT-Token wird als Query-Parameter uebergeben, da der Browser
- * bei window.open() keine Authorization-Header senden kann.
+ * Downloads werden ueber fetch() mit credentials: "include" durchgefuehrt,
+ * sodass die httpOnly JWT-Cookies automatisch mitgesendet werden.
+ *
+ * Fuer Endpunkte, die ueber window.open() aufgerufen werden muessen
+ * (z.B. direkte PDF-Ansicht), wird der QueryParameterJWTAuthentication
+ * Fallback im Backend verwendet. Da die Cookies bei same-origin window.open()
+ * automatisch mitgesendet werden, funktioniert auch das ohne Token-Parameter.
  *
  * Backend-Endpunkte:
- *   GET /api/v1/<resource>/export-xlsx/?token=<jwt>&<filter_params>
- *   GET /api/v1/<resource>/export-pdf/?token=<jwt>&<filter_params>
+ *   GET /api/v1/<resource>/export-xlsx/
+ *   GET /api/v1/<resource>/export-pdf/
  */
 
 export type ExportFormat = "xlsx" | "pdf" | "csv";
@@ -23,28 +26,18 @@ interface ExportOptions {
 }
 
 /**
- * Oeffnet eine Export-URL direkt im Browser.
- * Der JWT-Token wird als Query-Parameter angehaengt,
- * sodass der Browser den Download nativ handhabt.
+ * Download eine Export-Datei ueber fetch() mit Cookie-Authentifizierung.
+ * Erstellt einen temporaeren Blob-Download-Link.
  */
-export function downloadExport({
+export async function downloadExport({
   basePath,
   format,
   params = {},
-}: ExportOptions): void {
-  const token = typeof window !== "undefined"
-    ? localStorage.getItem("access_token")
-    : null;
-
-  if (!token) {
-    throw new Error("Nicht authentifiziert. Bitte erneut anmelden.");
-  }
-
+}: ExportOptions): Promise<void> {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "/api/v1";
 
-  // Build query string from params
+  // Build query string from params (without token)
   const searchParams = new URLSearchParams();
-  searchParams.set("token", token);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== "" && value !== "all") {
@@ -52,31 +45,79 @@ export function downloadExport({
     }
   });
 
-  const url = `${apiBase}${basePath}/export-${format}/?${searchParams.toString()}`;
+  const queryString = searchParams.toString();
+  const url = `${apiBase}${basePath}/export-${format}/${queryString ? `?${queryString}` : ""}`;
 
-  // Open in new window - browser handles the download natively
-  window.open(url, "_blank");
+  // Fetch with credentials to include httpOnly cookies
+  const response = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Export fehlgeschlagen: ${response.status} ${response.statusText}`);
+  }
+
+  // Extract filename from Content-Disposition header or generate default
+  const contentDisposition = response.headers.get("Content-Disposition");
+  let filename = `export.${format}`;
+  if (contentDisposition) {
+    const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    if (match?.[1]) {
+      filename = match[1].replace(/['"]/g, "");
+    }
+  }
+
+  // Create blob download
+  const blob = await response.blob();
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(blobUrl);
 }
 
 /**
- * Oeffnet eine einzelne Ressourcen-Export-URL direkt im Browser.
+ * Download eine einzelne Ressource ueber fetch() mit Cookie-Authentifizierung.
  * Fuer Detail-Exporte wie z.B. einzelne Wochenplan-PDFs.
  *
  * @param url - Relativer API-Pfad, z.B. "/weeklyplans/123/pdf/"
  */
-export function downloadDirectUrl(url: string): void {
-  const token = typeof window !== "undefined"
-    ? localStorage.getItem("access_token")
-    : null;
+export async function downloadDirectUrl(url: string): Promise<void> {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || "/api/v1";
+  const fullUrl = `${apiBase}${url}`;
 
-  if (!token) {
-    throw new Error("Nicht authentifiziert. Bitte erneut anmelden.");
+  // Fetch with credentials to include httpOnly cookies
+  const response = await fetch(fullUrl, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Download fehlgeschlagen: ${response.status} ${response.statusText}`);
   }
 
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || "/api/v1";
-  const separator = url.includes("?") ? "&" : "?";
-  const fullUrl = `${apiBase}${url}${separator}token=${token}`;
+  // Extract filename from Content-Disposition header
+  const contentDisposition = response.headers.get("Content-Disposition");
+  let filename = "download";
+  if (contentDisposition) {
+    const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    if (match?.[1]) {
+      filename = match[1].replace(/['"]/g, "");
+    }
+  }
 
-  // Open in new window - browser handles the download natively
-  window.open(fullUrl, "_blank");
+  // Create blob download
+  const blob = await response.blob();
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(blobUrl);
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,9 +4,9 @@ import type { NextRequest } from "next/server";
 /**
  * Next.js middleware for route protection.
  *
- * Since JWT tokens are stored in localStorage (client-side only),
- * we use a lightweight cookie-based flag to check auth status in middleware.
- * The actual token validation happens on the client side via the AuthProvider.
+ * JWT tokens are stored in httpOnly cookies managed by the backend.
+ * A lightweight `is_authenticated` cookie (non-httpOnly) is set by the
+ * AuthProvider to signal auth status to this middleware.
  *
  * Public routes: /login, /forgot-password, /reset-password, /api/*
  * Protected routes: everything else (dashboard, etc.)


### PR DESCRIPTION
## Änderungen

### Backend
- **JWT httpOnly Cookies:** Login-, Logout- und Token-Refresh-Endpunkte setzen Tokens als httpOnly/Secure/SameSite=Lax Cookies statt im Response Body
- **CookieJWTAuthentication:** Neue Auth-Klasse liest JWT aus httpOnly-Cookie (Fallback: Authorization Header)
- **QueryParameterJWTAuthentication:** Erweitert um Cookie-Support für File-Downloads
- **cookie_utils.py:** Zentrale Utility-Funktionen für Cookie-Management (set/clear)
- **2FA-Views:** Angepasst für Cookie-basierte Token-Ausgabe
- **Valkey/Redis:** Managed Valkey-Cluster auf DigitalOcean eingerichtet (Frankfurt/fra1)
- **Throttling:** Login-Throttling (5/min) und Password-Reset-Throttling (3/h) via Redis-Cache

### Frontend
- **auth-provider.tsx:** Refactored - entfernt localStorage Token-Handling, nutzt Cookies
- **api.ts:** Fetch-Aufrufe mit `credentials: 'include'` für Cookie-Übertragung
- **auth-api.ts:** Login/Logout/Refresh nutzen Cookie-basierte Auth
- **export.ts:** Download-Funktionen angepasst für Cookie-Auth
- **session-timeout:** Vereinfacht durch Cookie-basierte Token-Verwaltung
- **middleware.ts:** Angepasst für Cookie-basierte Auth-Prüfung

### Infrastruktur
- DigitalOcean Managed Valkey (Frankfurt/fra1) eingerichtet
- S3 Object Storage (gtsplaner-media) konfiguriert und getestet
- Redis-Cache für DRF Throttling aktiviert

## Getestete Szenarien
- Health-Check: ✅
- Login alle 4 Rollen (SuperAdmin, Admin, LocationManager, Educator): ✅
- API-Endpunkte (Benutzer, Standorte, Gruppen, Wochenpläne, Aufgaben, Finanzen): ✅
- Mandanten-Isolation: ✅

## Security
- OWASP A02 (Cryptographic Failures): JWT in httpOnly Cookies statt localStorage
- OWASP A05 (Security Misconfiguration): Redis-basiertes Rate Limiting
- OWASP A07 (Identification and Authentication Failures): Brute-Force-Schutz

Closes #261
Closes #262