### PR TITLE
fix: Token Refresh 500 Bug und Login-Redirect-Loop beheben

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -155,9 +155,8 @@ class CustomTokenRefreshView(APIView):
 
             # Rotate: create new refresh token and blacklist old one
             if settings.SIMPLE_JWT.get("ROTATE_REFRESH_TOKENS", False):
-                new_refresh = RefreshToken.for_user(old_token.payload.get("user_id"))
-                # Get user from old token to generate proper new token
                 from core.models import User
+
                 user_id = old_token.payload.get("user_id")
                 user = User.objects.get(pk=user_id)
                 new_refresh = RefreshToken.for_user(user)
@@ -181,10 +180,17 @@ class CustomTokenRefreshView(APIView):
             set_auth_cookies(response, new_access, new_refresh_str)
             return response
 
-        except (InvalidToken, TokenError) as e:
+        except (InvalidToken, TokenError):
             response = Response(
                 {"detail": "Ungültiger oder abgelaufener Refresh Token."},
                 status=status.HTTP_401_UNAUTHORIZED,
+            )
+            clear_auth_cookies(response)
+            return response
+        except Exception:
+            response = Response(
+                {"detail": "Token-Erneuerung fehlgeschlagen."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
             clear_auth_cookies(response)
             return response

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -36,17 +36,33 @@ const processQueue = (error: unknown) => {
   failedQueue = [];
 };
 
+/**
+ * Auth-related endpoints that should NOT trigger the automatic token refresh.
+ * These endpoints are called during auth flow itself, so retrying them
+ * would cause infinite loops.
+ */
+const AUTH_SKIP_URLS = [
+  "/auth/login",
+  "/auth/refresh",
+  "/auth/me",
+  "/auth/logout",
+  "/auth/2fa/login-verify",
+];
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
 
-    // Skip refresh for login and refresh endpoints
+    // Check if the URL matches any auth endpoint that should skip refresh
+    const shouldSkipRefresh = AUTH_SKIP_URLS.some((url) =>
+      originalRequest.url?.includes(url),
+    );
+
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      !originalRequest.url?.includes("/auth/login") &&
-      !originalRequest.url?.includes("/auth/refresh") &&
+      !shouldSkipRefresh &&
       typeof window !== "undefined"
     ) {
       if (isRefreshing) {
@@ -77,8 +93,11 @@ api.interceptors.response.use(
         return api(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError);
-        // Refresh failed – redirect to login
-        window.location.href = "/login";
+
+        // Refresh failed – only redirect if not already on /login to prevent loops
+        if (!window.location.pathname.startsWith("/login")) {
+          window.location.href = "/login";
+        }
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
## Problem
Die Login-Seite refreshte non-stop automatisch (Endlosschleife).

## Root Cause
1. `checkAuth()` ruft `/auth/me/` auf → 401 (nicht eingeloggt)
2. Axios-Interceptor fängt 401 ab → versucht `/auth/refresh/`
3. Refresh gibt 500 zurück (Bug: doppelter `RefreshToken.for_user()` Aufruf mit user_id String statt User-Objekt)
4. Refresh fehlschlägt → `window.location.href = '/login'`
5. Seite lädt neu → zurück zu Schritt 1

## Fixes

### Backend
- Doppelten `RefreshToken.for_user()` Aufruf in `CustomTokenRefreshView` entfernt
- Generischen Exception-Handler hinzugefügt (verhindert unkontrollierte 500er)

### Frontend
- `/auth/me/`, `/auth/logout/` und `/auth/2fa/login-verify/` vom Auto-Refresh-Interceptor ausgeschlossen
- Redirect-Loop-Schutz: kein Redirect zu `/login` wenn bereits auf `/login`

## Labels
Sprint-52