### PR TITLE
security: CSRF-Schutz korrekt implementieren für httpOnly-Cookie-Auth

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -51,7 +51,12 @@ if not DEBUG:
     SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
     # Cookie-Sicherheit
     SESSION_COOKIE_HTTPONLY = True
-    CSRF_COOKIE_HTTPONLY = True
+    # CSRF-Cookie muss für JavaScript lesbar sein (httpOnly=False),
+    # damit das SPA-Frontend den Token als X-CSRFToken Header mitsenden kann.
+    # Der CSRF-Token selbst ist kein Geheimnis – er schützt nur gegen
+    # Cross-Site-Request-Forgery, indem er beweist, dass der Request
+    # von unserer eigenen Domain stammt.
+    CSRF_COOKIE_HTTPONLY = False
     SESSION_COOKIE_SAMESITE = "Lax"
     CSRF_COOKIE_SAMESITE = "Lax"
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -9,6 +9,9 @@ The Authorization header is still supported for API clients.
 """
 
 from django.conf import settings
+from django.middleware.csrf import get_token
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from django.utils.decorators import method_decorator
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import permissions, status
 from rest_framework.response import Response
@@ -34,6 +37,8 @@ from core.serializers import (
 )
 
 
+@method_decorator(csrf_exempt, name="dispatch")
+@method_decorator(ensure_csrf_cookie, name="dispatch")
 class LoginView(APIView):
     """
     POST /api/v1/auth/login/
@@ -41,6 +46,10 @@ class LoginView(APIView):
     Authenticate a user with username/email and password.
     Returns user data and sets JWT tokens as httpOnly cookies.
     Rate limited to 5 attempts per minute to prevent brute-force attacks.
+
+    CSRF: exempt because this is the initial auth endpoint (no session yet).
+    ensure_csrf_cookie: sets the csrftoken cookie so the frontend can
+    include X-CSRFToken in subsequent state-changing requests.
     """
 
     permission_classes = [permissions.AllowAny]
@@ -99,20 +108,17 @@ class LogoutView(APIView):
         },
     )
     def post(self, request):
-        try:
-            # Try to get refresh token from cookie first, then from body
-            refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
-            if not refresh_token:
-                refresh_token = request.data.get("refresh")
+        # Try to get refresh token from cookie first, then from body
+        refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
+        if not refresh_token:
+            refresh_token = request.data.get("refresh")
 
-            if refresh_token:
-                try:
-                    token = RefreshToken(refresh_token)
-                    token.blacklist()
-                except Exception:
-                    pass  # Token may already be blacklisted or invalid
-        except Exception:
-            pass  # Ensure logout always succeeds
+        if refresh_token:
+            try:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+            except (InvalidToken, TokenError):
+                pass  # Token already blacklisted, expired, or invalid
 
         response = Response(
             {"detail": "Erfolgreich abgemeldet."},
@@ -122,12 +128,17 @@ class LogoutView(APIView):
         return response
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class CustomTokenRefreshView(APIView):
     """
     POST /api/v1/auth/refresh/
 
     Refresh the JWT access token using the refresh token from the httpOnly cookie.
     Sets new tokens as httpOnly cookies.
+
+    CSRF: exempt because this endpoint uses the refresh token cookie
+    for authentication, not the session. The refresh token itself
+    proves the request is legitimate.
     """
 
     permission_classes = [permissions.AllowAny]
@@ -263,6 +274,7 @@ class MeView(APIView):
         return Response(UserProfileSerializer(request.user).data)
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class PasswordResetRequestView(APIView):
     """
     POST /api/v1/auth/password-reset/
@@ -270,6 +282,8 @@ class PasswordResetRequestView(APIView):
     Request a password reset email.
     Always returns 200 to prevent email enumeration.
     Rate limited to 3 requests per hour to prevent abuse.
+
+    CSRF: exempt because this is a public endpoint (AllowAny).
     """
 
     permission_classes = [permissions.AllowAny]
@@ -331,11 +345,15 @@ class PasswordResetRequestView(APIView):
         )
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class PasswordResetConfirmView(APIView):
     """
     POST /api/v1/auth/password-reset/confirm/
 
     Confirm a password reset with uid, token, and new password.
+
+    CSRF: exempt because this is a public endpoint (AllowAny).
+    The reset token itself proves the request is legitimate.
     """
 
     permission_classes = [permissions.AllowAny]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,15 +7,44 @@ import axios from "axios";
  * The `withCredentials: true` flag ensures cookies are sent with every request.
  * No manual token management is needed on the client side.
  *
+ * CSRF protection:
+ * Django sets a `csrftoken` cookie (non-httpOnly) after login.
+ * This instance reads the cookie and sends it as the `X-CSRFToken` header
+ * on every state-changing request (POST, PUT, PATCH, DELETE).
+ *
  * Token refresh is handled automatically on 401 responses by calling
  * the /auth/refresh/ endpoint (which reads the refresh token from its cookie).
  */
+
+/**
+ * Read a cookie value by name from document.cookie.
+ */
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp("(^|;\\s*)" + name + "=([^;]*)"),
+  );
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "/api/v1",
   headers: {
     "Content-Type": "application/json",
   },
   withCredentials: true,
+});
+
+// Request interceptor: attach CSRF token to state-changing requests
+api.interceptors.request.use((config) => {
+  const method = config.method?.toUpperCase();
+  if (method && ["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    const csrfToken = getCookie("csrftoken");
+    if (csrfToken) {
+      config.headers["X-CSRFToken"] = csrfToken;
+    }
+  }
+  return config;
 });
 
 // Response interceptor: handle 401 with silent token refresh via cookies


### PR DESCRIPTION
## Problem
Nach der Umstellung auf httpOnly-Cookie-Auth fehlte der CSRF-Schutz:
- `CSRF_COOKIE_HTTPONLY = True` verhinderte, dass das Frontend den CSRF-Token lesen konnte
- Logout gab 500 zurück (CSRF-Rejection durch Django Middleware)
- Vorheriger Fix war ein unsicheres blindes `try/except`

## Lösung

### Backend
- `CSRF_COOKIE_HTTPONLY = False`: CSRF-Cookie muss für JavaScript lesbar sein
- `LoginView`: `@csrf_exempt` + `@ensure_csrf_cookie` → setzt csrftoken-Cookie bei Login
- `CustomTokenRefreshView`: `@csrf_exempt` (AllowAny, Refresh-Token reicht als Beweis)
- `PasswordResetRequest/Confirm`: `@csrf_exempt` (öffentliche Endpoints)
- `LogoutView`: Workaround revertiert, gezieltes `except (InvalidToken, TokenError)`

### Frontend
- Request-Interceptor liest `csrftoken`-Cookie und sendet `X-CSRFToken` Header
- Gilt für alle POST/PUT/PATCH/DELETE Requests

## Sicherheitsmodell
| Endpoint | Auth | CSRF |
|---|---|---|
| Login | AllowAny | exempt (+ setzt Cookie) |
| Refresh | AllowAny | exempt (Token = Beweis) |
| Password Reset | AllowAny | exempt (öffentlich) |
| Logout | IsAuthenticated | **geschützt** |
| Me (PATCH) | IsAuthenticated | **geschützt** |
| AcceptTerms | IsAuthenticated | **geschützt** |
| PasswordChange | IsAuthenticated | **geschützt** |
| Alle anderen API-Views | IsAuthenticated | **geschützt** |