### PR TITLE
fix: Logout 500 - delete_cookie() akzeptiert kein 'secure' Parameter

### DIFF
--- a/backend/core/cookie_utils.py
+++ b/backend/core/cookie_utils.py
@@ -82,9 +82,11 @@ def clear_auth_cookies(response: Response) -> Response:
         The response with cookies cleared.
     """
     defaults = _get_cookie_defaults()
-    # Remove httponly from kwargs for delete_cookie (not supported)
+    # delete_cookie() only accepts: path, domain, samesite
+    # It does NOT accept httponly or secure (Django 4.x+)
+    allowed_delete_keys = {"path", "domain", "samesite"}
     delete_kwargs = {
-        k: v for k, v in defaults.items() if k != "httponly"
+        k: v for k, v in defaults.items() if k in allowed_delete_keys
     }
 
     response.delete_cookie(ACCESS_TOKEN_COOKIE, **delete_kwargs)


### PR DESCRIPTION
## Root Cause

`Django's HttpResponseBase.delete_cookie()` akzeptiert nur `path`, `domain` und `samesite` als Parameter. Der `secure` Parameter aus `_get_cookie_defaults()` wurde fälschlicherweise an `delete_cookie()` übergeben.

## Traceback (aus Produktiv-Logs)

```
File cookie_utils.py, line 90, in clear_auth_cookies
    response.delete_cookie(ACCESS_TOKEN_COOKIE, **delete_kwargs)
TypeError: HttpResponseBase.delete_cookie() got an unexpected keyword argument 'secure'
```

## Fix

Whitelist-Ansatz: Nur erlaubte Parameter (`path`, `domain`, `samesite`) werden an `delete_cookie()` weitergegeben.

Closes #262