### PR TITLE
Sprint 57: E-Mail-Benachrichtigungen und Passwort-Reset

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,8 +38,17 @@ AWS_SECRET_ACCESS_KEY=
 # CORS
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
-# Email (Entwicklung: Console Backend)
+# Email (Entwicklung: Console Backend, Produktion: SMTP)
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+EMAIL_HOST=mail.your-server.de
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=auto_benachrichtigungen@gtsplaner.app
+EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=GTS Planer <auto_benachrichtigungen@gtsplaner.app>
+
+# Frontend URL (fuer Passwort-Reset-Links etc.)
+FRONTEND_URL=http://localhost:3000
 
 # JWT
 JWT_ACCESS_TOKEN_LIFETIME_MINUTES=60

--- a/backend/system/tasks.py
+++ b/backend/system/tasks.py
@@ -5,7 +5,9 @@ Handles asynchronous email sending for:
 - Transaction approval/rejection notifications
 - Leave request approval/rejection notifications
 - Password reset emails
+- Task assignment and status change notifications
 - System notifications
+- GDPR data retention cleanup
 """
 
 import logging
@@ -17,6 +19,24 @@ from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 
 logger = logging.getLogger("kassenbuch.tasks")
+
+
+def _get_frontend_url():
+    """Return the configured frontend URL."""
+    return getattr(settings, "FRONTEND_URL", "https://www.gtsplaner.app")
+
+
+def _render_email(template_name, context, fallback_plain):
+    """
+    Render an HTML email template with plain-text fallback.
+
+    Returns a tuple (plain_message, html_message).
+    If the template cannot be rendered, html_message is None.
+    """
+    context.setdefault("frontend_url", _get_frontend_url())
+    html_message = render_to_string(template_name, context)
+    plain_message = strip_tags(html_message)
+    return plain_message, html_message
 
 
 # ---------------------------------------------------------------------------
@@ -33,67 +53,55 @@ def send_transaction_status_notification(self, transaction_id, new_status):
         transaction_id: ID of the transaction
         new_status: New status (approved, rejected)
     """
-    try:
-        from finance.models import Transaction
+    from finance.models import Transaction
 
-        transaction = Transaction.objects.select_related(
-            "created_by", "approved_by", "group", "category"
-        ).get(pk=transaction_id)
+    transaction = Transaction.objects.select_related(
+        "created_by", "approved_by", "group", "category"
+    ).get(pk=transaction_id)
 
-        user = transaction.created_by
-        if not user or not user.email:
-            logger.warning(f"Transaction #{transaction_id}: No email for user")
-            return
+    user = transaction.created_by
+    if not user or not user.email:
+        logger.warning(f"Transaction #{transaction_id}: No email for user")
+        return
 
-        status_display = {
-            "approved": "genehmigt",
-            "rejected": "abgelehnt",
-        }.get(new_status, new_status)
+    status_display = {
+        "approved": "genehmigt",
+        "rejected": "abgelehnt",
+    }.get(new_status, new_status)
 
-        subject = f"Transaktion #{transaction.id} wurde {status_display}"
+    subject = f"Transaktion #{transaction.id} wurde {status_display}"
 
-        context = {
-            "user": user,
-            "transaction": transaction,
-            "status_display": status_display,
-            "approved_by": transaction.approved_by,
-            "site_name": "GTS Planner",
-        }
+    context = {
+        "user": user,
+        "transaction": transaction,
+        "status_display": status_display,
+        "approved_by": transaction.approved_by,
+        "site_name": "GTS Planner",
+    }
 
-        # Try template, fallback to plain text
-        try:
-            html_message = render_to_string("emails/transaction_status.html", context)
-            plain_message = strip_tags(html_message)
-        except Exception:
-            plain_message = (
-                f"Hallo {user.first_name},\n\n"
-                f"Ihre Transaktion #{transaction.id} ({transaction.description}) "
-                f"über € {transaction.amount} wurde {status_display}.\n\n"
-                f"Datum: {transaction.transaction_date}\n"
-                f"Gruppe: {transaction.group.name if transaction.group else '-'}\n"
-                f"Kategorie: {transaction.category.name if transaction.category else '-'}\n"
-            )
-            if transaction.approved_by:
-                plain_message += f"Bearbeitet von: {transaction.approved_by.get_full_name()}\n"
-            if hasattr(transaction, "approval_notes") and transaction.approval_notes:
-                plain_message += f"Anmerkung: {transaction.approval_notes}\n"
-            plain_message += f"\nMit freundlichen Grüßen,\nGTS Planner"
-            html_message = None
+    plain_fallback = (
+        f"Hallo {user.first_name},\n\n"
+        f"Ihre Transaktion #{transaction.id} ({transaction.description}) "
+        f"über € {transaction.amount} wurde {status_display}.\n\n"
+        f"Mit freundlichen Grüßen,\nGTS Planner"
+    )
 
-        send_mail(
-            subject=subject,
-            message=plain_message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[user.email],
-            html_message=html_message,
-            fail_silently=False,
-        )
+    plain_message, html_message = _render_email(
+        "emails/transaction_status.html", context, plain_fallback
+    )
 
-        logger.info(f"Transaction status notification sent to {user.email} for #{transaction_id}")
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+        html_message=html_message,
+        fail_silently=False,
+    )
 
-    except Exception as exc:
-        logger.error(f"Failed to send transaction notification for #{transaction_id}: {exc}")
-        raise self.retry(exc=exc)
+    logger.info(
+        f"Transaction status notification sent to {user.email} for #{transaction_id}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -110,51 +118,50 @@ def send_leave_request_status_notification(self, leave_request_id, new_status):
         leave_request_id: ID of the leave request
         new_status: New status (approved, rejected)
     """
-    try:
-        from timetracking.models import LeaveRequest
+    from timetracking.models import LeaveRequest
 
-        leave = LeaveRequest.objects.select_related(
-            "user", "leave_type", "approved_by"
-        ).get(pk=leave_request_id)
+    leave = LeaveRequest.objects.select_related(
+        "user", "leave_type", "approved_by"
+    ).get(pk=leave_request_id)
 
-        user = leave.user
-        if not user or not user.email:
-            logger.warning(f"LeaveRequest #{leave_request_id}: No email for user")
-            return
+    user = leave.user
+    if not user or not user.email:
+        logger.warning(f"LeaveRequest #{leave_request_id}: No email for user")
+        return
 
-        status_display = {
-            "approved": "genehmigt",
-            "rejected": "abgelehnt",
-        }.get(new_status, new_status)
+    status_display = {
+        "approved": "genehmigt",
+        "rejected": "abgelehnt",
+    }.get(new_status, new_status)
 
-        subject = f"Urlaubsantrag #{leave.id} wurde {status_display}"
+    subject = f"Urlaubsantrag #{leave.id} wurde {status_display}"
 
-        plain_message = (
-            f"Hallo {user.first_name},\n\n"
-            f"Ihr Urlaubsantrag #{leave.id} wurde {status_display}.\n\n"
-            f"Typ: {leave.leave_type.name if leave.leave_type else '-'}\n"
-            f"Zeitraum: {leave.start_date} bis {leave.end_date}\n"
-            f"Tage: {leave.total_days}\n"
+    plain_message = (
+        f"Hallo {user.first_name},\n\n"
+        f"Ihr Urlaubsantrag #{leave.id} wurde {status_display}.\n\n"
+        f"Typ: {leave.leave_type.name if leave.leave_type else '-'}\n"
+        f"Zeitraum: {leave.start_date} bis {leave.end_date}\n"
+        f"Tage: {leave.total_days}\n"
+    )
+    if leave.approved_by:
+        plain_message += (
+            f"Bearbeitet von: {leave.approved_by.get_full_name()}\n"
         )
-        if leave.approved_by:
-            plain_message += f"Bearbeitet von: {leave.approved_by.get_full_name()}\n"
-        if leave.approval_notes:
-            plain_message += f"Anmerkung: {leave.approval_notes}\n"
-        plain_message += f"\nMit freundlichen Grüßen,\nGTS Planner"
+    if leave.approval_notes:
+        plain_message += f"Anmerkung: {leave.approval_notes}\n"
+    plain_message += "\nMit freundlichen Grüßen,\nGTS Planner"
 
-        send_mail(
-            subject=subject,
-            message=plain_message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[user.email],
-            fail_silently=False,
-        )
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+        fail_silently=False,
+    )
 
-        logger.info(f"Leave request notification sent to {user.email} for #{leave_request_id}")
-
-    except Exception as exc:
-        logger.error(f"Failed to send leave request notification for #{leave_request_id}: {exc}")
-        raise self.retry(exc=exc)
+    logger.info(
+        f"Leave request notification sent to {user.email} for #{leave_request_id}"
+    )
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
@@ -165,55 +172,54 @@ def send_new_leave_request_notification(self, leave_request_id):
     Args:
         leave_request_id: ID of the new leave request
     """
-    try:
-        from core.models import User
-        from timetracking.models import LeaveRequest
+    from core.models import User
+    from timetracking.models import LeaveRequest
 
-        leave = LeaveRequest.objects.select_related("user", "leave_type").get(pk=leave_request_id)
+    leave = LeaveRequest.objects.select_related("user", "leave_type").get(
+        pk=leave_request_id
+    )
 
-        # Find location managers for the user's location
-        managers = User.objects.filter(
-            role__in=["location_manager", "admin", "super_admin"],
-            location=leave.user.location,
-            is_active=True,
-            is_deleted=False,
-        ).exclude(email="")
+    # Find location managers for the user's location
+    managers = User.objects.filter(
+        role__in=["location_manager", "admin", "super_admin"],
+        location=leave.user.location,
+        is_active=True,
+        is_deleted=False,
+    ).exclude(email="")
 
-        if not managers.exists():
-            logger.warning(f"No managers found for leave request #{leave_request_id}")
-            return
-
-        subject = f"Neuer Urlaubsantrag von {leave.user.get_full_name()}"
-
-        plain_message = (
-            f"Ein neuer Urlaubsantrag wurde eingereicht.\n\n"
-            f"Mitarbeiter:in: {leave.user.get_full_name()}\n"
-            f"Typ: {leave.leave_type.name if leave.leave_type else '-'}\n"
-            f"Zeitraum: {leave.start_date} bis {leave.end_date}\n"
-            f"Tage: {leave.total_days}\n"
-            f"Grund: {leave.reason or '-'}\n\n"
-            f"Bitte genehmigen oder ablehnen Sie diesen Antrag im GTS Planner.\n\n"
-            f"Mit freundlichen Grüßen,\nGTS Planner"
+    if not managers.exists():
+        logger.warning(
+            f"No managers found for leave request #{leave_request_id}"
         )
+        return
 
-        recipient_list = list(managers.values_list("email", flat=True))
+    subject = f"Neuer Urlaubsantrag von {leave.user.get_full_name()}"
 
-        send_mail(
-            subject=subject,
-            message=plain_message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=recipient_list,
-            fail_silently=False,
-        )
+    plain_message = (
+        f"Ein neuer Urlaubsantrag wurde eingereicht.\n\n"
+        f"Mitarbeiter:in: {leave.user.get_full_name()}\n"
+        f"Typ: {leave.leave_type.name if leave.leave_type else '-'}\n"
+        f"Zeitraum: {leave.start_date} bis {leave.end_date}\n"
+        f"Tage: {leave.total_days}\n"
+        f"Grund: {leave.reason or '-'}\n\n"
+        f"Bitte genehmigen oder ablehnen Sie diesen Antrag im GTS Planner.\n\n"
+        f"Mit freundlichen Grüßen,\nGTS Planner"
+    )
 
-        logger.info(
-            f"New leave request notification sent to {len(recipient_list)} managers "
-            f"for #{leave_request_id}"
-        )
+    recipient_list = list(managers.values_list("email", flat=True))
 
-    except Exception as exc:
-        logger.error(f"Failed to send new leave request notification for #{leave_request_id}: {exc}")
-        raise self.retry(exc=exc)
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=recipient_list,
+        fail_silently=False,
+    )
+
+    logger.info(
+        f"New leave request notification sent to {len(recipient_list)} managers "
+        f"for #{leave_request_id}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -226,45 +232,181 @@ def send_password_reset_email(self, user_id, reset_link):
     """
     Send password reset email to user with a link to the frontend reset page.
 
+    Uses an HTML template with a plain-text fallback.
+
     Args:
         user_id: ID of the user requesting reset
         reset_link: Full URL to the frontend password reset page with uid and token
     """
-    try:
-        from core.models import User
+    from core.models import User
 
-        user = User.objects.get(pk=user_id)
+    user = User.objects.get(pk=user_id)
 
-        if not user.email:
-            logger.warning(f"User #{user_id}: No email address")
-            return
+    if not user.email:
+        logger.warning(f"User #{user_id}: No email address")
+        return
 
-        subject = "Passwort zurücksetzen – GTS Planner"
+    subject = "Passwort zurücksetzen – GTS Planner"
 
-        plain_message = (
-            f"Hallo {user.first_name},\n\n"
-            f"Sie haben eine Passwort-Zurücksetzung angefordert.\n\n"
-            f"Klicken Sie auf den folgenden Link, um Ihr Passwort zurückzusetzen:\n"
-            f"{reset_link}\n\n"
-            f"Dieser Link ist 24 Stunden gültig.\n\n"
-            f"Falls Sie diese Anfrage nicht gestellt haben, "
-            f"ignorieren Sie bitte diese E-Mail.\n\n"
-            f"Mit freundlichen Grüßen,\nGTS Planner"
+    context = {
+        "first_name": user.first_name or user.username,
+        "reset_link": reset_link,
+    }
+
+    plain_fallback = (
+        f"Hallo {user.first_name},\n\n"
+        f"Sie haben eine Passwort-Zurücksetzung angefordert.\n\n"
+        f"Klicken Sie auf den folgenden Link, um Ihr Passwort zurückzusetzen:\n"
+        f"{reset_link}\n\n"
+        f"Dieser Link ist 24 Stunden gültig.\n\n"
+        f"Falls Sie diese Anfrage nicht gestellt haben, "
+        f"ignorieren Sie bitte diese E-Mail.\n\n"
+        f"Mit freundlichen Grüßen,\nGTS Planner"
+    )
+
+    plain_message, html_message = _render_email(
+        "emails/password_reset.html", context, plain_fallback
+    )
+
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+        html_message=html_message,
+        fail_silently=False,
+    )
+
+    logger.info(f"Password reset email sent to {user.email}")
+
+
+# ---------------------------------------------------------------------------
+# Task Notifications (NEW – Sprint 57)
+# ---------------------------------------------------------------------------
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_task_assigned_email(self, task_id):
+    """
+    Send email notification when a task is assigned to a user.
+
+    Args:
+        task_id: ID of the newly created/assigned task
+    """
+    from tasks.models import Task
+
+    task = Task.objects.select_related(
+        "assigned_to", "created_by", "location", "organization"
+    ).get(pk=task_id)
+
+    recipient = task.assigned_to
+    if not recipient or not recipient.email:
+        logger.warning(f"Task #{task_id}: No email for assigned user")
+        return
+
+    priority_labels = dict(Task.Priority.choices)
+    subject = f"Neue Aufgabe: {task.title}"
+
+    context = {
+        "assigned_to_name": recipient.get_full_name() or recipient.username,
+        "task_title": task.title,
+        "description": task.description,
+        "priority_display": priority_labels.get(task.priority, task.priority),
+        "due_date": task.due_date.strftime("%d.%m.%Y") if task.due_date else "-",
+        "created_by_name": (
+            task.created_by.get_full_name() if task.created_by else "-"
+        ),
+        "location_name": task.location.name if task.location else None,
+    }
+
+    plain_fallback = (
+        f"Hallo {recipient.first_name},\n\n"
+        f"Ihnen wurde eine neue Aufgabe zugewiesen: {task.title}\n\n"
+        f"Priorität: {context['priority_display']}\n"
+        f"Stichtag: {context['due_date']}\n"
+        f"Erstellt von: {context['created_by_name']}\n\n"
+        f"Mit freundlichen Grüßen,\nGTS Planner"
+    )
+
+    plain_message, html_message = _render_email(
+        "emails/task_assigned.html", context, plain_fallback
+    )
+
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[recipient.email],
+        html_message=html_message,
+        fail_silently=False,
+    )
+
+    logger.info(
+        f"Task assignment email sent to {recipient.email} for task #{task_id}"
+    )
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_task_status_changed_email(self, task_id, old_status, new_status, changed_by_id):
+    """
+    Send email notification when a task status changes.
+
+    Args:
+        task_id: ID of the task
+        old_status: Previous status string
+        new_status: New status string
+        changed_by_id: ID of the user who changed the status
+    """
+    from core.models import User
+    from tasks.models import Task
+
+    task = Task.objects.select_related("created_by", "assigned_to").get(pk=task_id)
+    changed_by = User.objects.get(pk=changed_by_id)
+
+    # Notify the task creator (if they didn't make the change themselves)
+    recipient = task.created_by
+    if not recipient or not recipient.email or recipient.pk == changed_by_id:
+        logger.info(
+            f"Task #{task_id}: Skipping status email (creator is the changer or no email)"
         )
+        return
 
-        send_mail(
-            subject=subject,
-            message=plain_message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[user.email],
-            fail_silently=False,
-        )
+    status_labels = dict(Task.Status.choices)
+    subject = f"Aufgabe aktualisiert: {task.title}"
 
-        logger.info(f"Password reset email sent to {user.email}")
+    context = {
+        "recipient_name": recipient.get_full_name() or recipient.username,
+        "task_title": task.title,
+        "old_status_display": status_labels.get(old_status, old_status),
+        "new_status_display": status_labels.get(new_status, new_status),
+        "changed_by_name": changed_by.get_full_name() or changed_by.username,
+    }
 
-    except Exception as exc:
-        logger.error(f"Failed to send password reset email for user #{user_id}: {exc}")
-        raise self.retry(exc=exc)
+    plain_fallback = (
+        f"Hallo {recipient.first_name},\n\n"
+        f"Der Status der Aufgabe \"{task.title}\" wurde von "
+        f"\"{context['old_status_display']}\" auf \"{context['new_status_display']}\" "
+        f"geändert.\n\n"
+        f"Geändert von: {context['changed_by_name']}\n\n"
+        f"Mit freundlichen Grüßen,\nGTS Planner"
+    )
+
+    plain_message, html_message = _render_email(
+        "emails/task_status_changed.html", context, plain_fallback
+    )
+
+    send_mail(
+        subject=subject,
+        message=plain_message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[recipient.email],
+        html_message=html_message,
+        fail_silently=False,
+    )
+
+    logger.info(
+        f"Task status change email sent to {recipient.email} for task #{task_id}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -282,17 +424,14 @@ def send_system_notification(subject, message, recipient_emails):
         message: Email body (plain text)
         recipient_emails: List of email addresses
     """
-    try:
-        send_mail(
-            subject=subject,
-            message=message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=recipient_emails,
-            fail_silently=False,
-        )
-        logger.info(f"System notification sent to {len(recipient_emails)} recipients")
-    except Exception as e:
-        logger.error(f"Failed to send system notification: {e}")
+    send_mail(
+        subject=subject,
+        message=message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=recipient_emails,
+        fail_silently=False,
+    )
+    logger.info(f"System notification sent to {len(recipient_emails)} recipients")
 
 
 # ---------------------------------------------------------------------------
@@ -324,11 +463,10 @@ def gdpr_cleanup_expired_data():
     from system.models import AuditLog, SystemSetting
 
     # Get retention period from SystemSetting (default: 7 years)
-    try:
-        setting = SystemSetting.objects.get(key="data_retention_years")
+    retention_years = 7
+    setting = SystemSetting.objects.filter(key="data_retention_years").first()
+    if setting:
         retention_years = int(setting.value)
-    except (SystemSetting.DoesNotExist, ValueError):
-        retention_years = 7
 
     cutoff_date = timezone.now() - timedelta(days=retention_years * 365)
 

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -5,6 +5,8 @@ Provides CRUD operations for tasks, a board endpoint for Kanban view,
 and a status change endpoint that triggers notifications.
 """
 
+import logging
+
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
@@ -23,6 +25,7 @@ from tasks.serializers import (
 )
 
 User = get_user_model()
+logger = logging.getLogger("kassenbuch.tasks")
 
 
 class TaskViewSet(ExportMixin, viewsets.ModelViewSet):
@@ -104,21 +107,43 @@ class TaskViewSet(ExportMixin, viewsets.ModelViewSet):
         )
 
     def create(self, request, *args, **kwargs):
-        """Create task and return full detail serializer."""
+        """Create task, send email notification, and return full detail serializer."""
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
+
+        task = serializer.instance
+
+        # Send email notification to the assigned user (async via Celery)
+        if task.assigned_to and task.assigned_to != request.user:
+            self._send_task_assigned_email(task)
+
+        # Create in-app notification for the assigned user
+        if task.assigned_to and task.assigned_to != request.user:
+            self._create_assignment_notification(task)
+
         # Return the full detail serializer
-        detail_serializer = TaskListSerializer(serializer.instance)
+        detail_serializer = TaskListSerializer(task)
         return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         """Update task and return full detail serializer."""
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+        old_assigned_to = instance.assigned_to_id
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+
+        # If the task was reassigned to a different user, send notification
+        if (
+            instance.assigned_to_id != old_assigned_to
+            and instance.assigned_to
+            and instance.assigned_to != request.user
+        ):
+            self._send_task_assigned_email(instance)
+            self._create_assignment_notification(instance)
+
         detail_serializer = TaskListSerializer(instance)
         return Response(detail_serializer.data)
 
@@ -157,6 +182,8 @@ class TaskViewSet(ExportMixin, viewsets.ModelViewSet):
         # Create in-app notification for the task creator
         if task.created_by != request.user:
             self._create_status_notification(task, old_status, new_status, request.user)
+            # Send email notification for status change (async via Celery)
+            self._send_task_status_email(task, old_status, new_status, request.user)
 
         detail_serializer = TaskListSerializer(task)
         return Response(detail_serializer.data)
@@ -244,6 +271,54 @@ class TaskViewSet(ExportMixin, viewsets.ModelViewSet):
         ]
 
         return Response(data)
+
+    # -----------------------------------------------------------------------
+    # Private helpers
+    # -----------------------------------------------------------------------
+
+    def _send_task_assigned_email(self, task):
+        """Send an async email notification for task assignment."""
+        from system.tasks import send_task_assigned_email
+
+        try:
+            send_task_assigned_email.delay(task.pk)
+        except Exception:
+            logger.warning(
+                "Celery/Redis unavailable – sending task assignment email synchronously"
+            )
+            send_task_assigned_email(task.pk)
+
+    def _send_task_status_email(self, task, old_status, new_status, changed_by):
+        """Send an async email notification for task status change."""
+        from system.tasks import send_task_status_changed_email
+
+        try:
+            send_task_status_changed_email.delay(
+                task.pk, old_status, new_status, changed_by.pk
+            )
+        except Exception:
+            logger.warning(
+                "Celery/Redis unavailable – sending task status email synchronously"
+            )
+            send_task_status_changed_email(
+                task.pk, old_status, new_status, changed_by.pk
+            )
+
+    def _create_assignment_notification(self, task):
+        """Create an in-app notification for task assignment."""
+        from system.models import InAppNotification
+
+        InAppNotification.objects.create(
+            recipient=task.assigned_to,
+            title=f"Neue Aufgabe: {task.title}",
+            message=(
+                f"{task.created_by.get_full_name()} hat Ihnen die Aufgabe "
+                f'"{task.title}" zugewiesen.'
+            ),
+            notification_type="task_assigned",
+            related_task=task,
+            organization=task.organization,
+        )
 
     def _create_status_notification(self, task, old_status, new_status, changed_by):
         """Create an in-app notification for the task creator."""

--- a/backend/templates/emails/base.html
+++ b/backend/templates/emails/base.html
@@ -1,0 +1,126 @@
+{% autoescape off %}<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}GTS Planer{% endblock %}</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f4f4f5;
+      color: #18181b;
+      line-height: 1.6;
+    }
+    .wrapper {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    .card {
+      background-color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      overflow: hidden;
+    }
+    .header {
+      background-color: #1a1a1a;
+      padding: 24px 32px;
+      text-align: center;
+    }
+    .header h1 {
+      margin: 0;
+      color: #FFCC00;
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    .content {
+      padding: 32px;
+    }
+    .content p {
+      margin: 0 0 16px;
+      font-size: 15px;
+      color: #3f3f46;
+    }
+    .content p:last-child {
+      margin-bottom: 0;
+    }
+    .btn {
+      display: inline-block;
+      padding: 12px 28px;
+      background-color: #FFCC00;
+      color: #1a1a1a !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 15px;
+      margin: 8px 0 16px;
+    }
+    .btn:hover {
+      background-color: #FFD633;
+    }
+    .info-box {
+      background-color: #fefce8;
+      border-left: 4px solid #FFCC00;
+      padding: 16px;
+      border-radius: 0 8px 8px 0;
+      margin: 16px 0;
+    }
+    .info-box p {
+      margin: 0;
+      font-size: 14px;
+      color: #713f12;
+    }
+    .detail-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0;
+    }
+    .detail-table td {
+      padding: 8px 0;
+      font-size: 14px;
+      border-bottom: 1px solid #f4f4f5;
+    }
+    .detail-table td:first-child {
+      color: #71717a;
+      width: 40%;
+    }
+    .detail-table td:last-child {
+      color: #18181b;
+      font-weight: 500;
+    }
+    .footer {
+      padding: 24px 32px;
+      text-align: center;
+      border-top: 1px solid #f4f4f5;
+    }
+    .footer p {
+      margin: 0;
+      font-size: 12px;
+      color: #a1a1aa;
+    }
+    .footer a {
+      color: #71717a;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="card">
+      <div class="header">
+        <h1>GTS Planer</h1>
+      </div>
+      <div class="content">
+        {% block content %}{% endblock %}
+      </div>
+      <div class="footer">
+        <p>Hilfswerk &Ouml;sterreich &ndash; GTS Planer</p>
+        <p style="margin-top: 4px;"><a href="{{ frontend_url }}">{{ frontend_url }}</a></p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>{% endautoescape %}

--- a/backend/templates/emails/password_reset.html
+++ b/backend/templates/emails/password_reset.html
@@ -1,0 +1,22 @@
+{% extends "emails/base.html" %}
+{% block title %}Passwort zurücksetzen – GTS Planer{% endblock %}
+{% block content %}
+<p>Hallo {{ first_name }},</p>
+
+<p>Sie haben eine Passwort-Zur&uuml;cksetzung f&uuml;r Ihr GTS Planer Konto angefordert.</p>
+
+<p>Klicken Sie auf den folgenden Button, um ein neues Passwort zu setzen:</p>
+
+<p style="text-align: center;">
+  <a href="{{ reset_link }}" class="btn">Passwort zur&uuml;cksetzen</a>
+</p>
+
+<div class="info-box">
+  <p>Dieser Link ist <strong>24 Stunden</strong> g&uuml;ltig. Falls Sie diese Anfrage nicht gestellt haben, k&ouml;nnen Sie diese E-Mail ignorieren.</p>
+</div>
+
+<p style="font-size: 13px; color: #71717a;">
+  Falls der Button nicht funktioniert, kopieren Sie den folgenden Link in Ihren Browser:<br>
+  <a href="{{ reset_link }}" style="color: #71717a; word-break: break-all;">{{ reset_link }}</a>
+</p>
+{% endblock %}

--- a/backend/templates/emails/task_assigned.html
+++ b/backend/templates/emails/task_assigned.html
@@ -1,0 +1,42 @@
+{% extends "emails/base.html" %}
+{% block title %}Neue Aufgabe zugewiesen – GTS Planer{% endblock %}
+{% block content %}
+<p>Hallo {{ assigned_to_name }},</p>
+
+<p>Ihnen wurde eine neue Aufgabe im GTS Planer zugewiesen:</p>
+
+<table class="detail-table">
+  <tr>
+    <td>Titel</td>
+    <td>{{ task_title }}</td>
+  </tr>
+  <tr>
+    <td>Priorit&auml;t</td>
+    <td>{{ priority_display }}</td>
+  </tr>
+  <tr>
+    <td>Stichtag</td>
+    <td>{{ due_date }}</td>
+  </tr>
+  <tr>
+    <td>Erstellt von</td>
+    <td>{{ created_by_name }}</td>
+  </tr>
+  {% if location_name %}
+  <tr>
+    <td>Standort</td>
+    <td>{{ location_name }}</td>
+  </tr>
+  {% endif %}
+</table>
+
+{% if description %}
+<div class="info-box">
+  <p><strong>Beschreibung:</strong> {{ description }}</p>
+</div>
+{% endif %}
+
+<p style="text-align: center;">
+  <a href="{{ frontend_url }}/tasks" class="btn">&Ouml;ffne Aufgaben</a>
+</p>
+{% endblock %}

--- a/backend/templates/emails/task_status_changed.html
+++ b/backend/templates/emails/task_status_changed.html
@@ -1,0 +1,30 @@
+{% extends "emails/base.html" %}
+{% block title %}Aufgabenstatus geändert – GTS Planer{% endblock %}
+{% block content %}
+<p>Hallo {{ recipient_name }},</p>
+
+<p>Der Status einer Ihrer Aufgaben wurde ge&auml;ndert:</p>
+
+<table class="detail-table">
+  <tr>
+    <td>Aufgabe</td>
+    <td>{{ task_title }}</td>
+  </tr>
+  <tr>
+    <td>Alter Status</td>
+    <td>{{ old_status_display }}</td>
+  </tr>
+  <tr>
+    <td>Neuer Status</td>
+    <td>{{ new_status_display }}</td>
+  </tr>
+  <tr>
+    <td>Ge&auml;ndert von</td>
+    <td>{{ changed_by_name }}</td>
+  </tr>
+</table>
+
+<p style="text-align: center;">
+  <a href="{{ frontend_url }}/tasks" class="btn">&Ouml;ffne Aufgaben</a>
+</p>
+{% endblock %}

--- a/backend/templates/emails/transaction_status.html
+++ b/backend/templates/emails/transaction_status.html
@@ -1,0 +1,44 @@
+{% extends "emails/base.html" %}
+{% block title %}Transaktion {{ status_display }} – GTS Planer{% endblock %}
+{% block content %}
+<p>Hallo {{ user.first_name }},</p>
+
+<p>Ihre Transaktion wurde <strong>{{ status_display }}</strong>:</p>
+
+<table class="detail-table">
+  <tr>
+    <td>Transaktion</td>
+    <td>#{{ transaction.id }} &ndash; {{ transaction.description }}</td>
+  </tr>
+  <tr>
+    <td>Betrag</td>
+    <td>&euro; {{ transaction.amount }}</td>
+  </tr>
+  <tr>
+    <td>Datum</td>
+    <td>{{ transaction.transaction_date }}</td>
+  </tr>
+  {% if transaction.group %}
+  <tr>
+    <td>Gruppe</td>
+    <td>{{ transaction.group.name }}</td>
+  </tr>
+  {% endif %}
+  {% if transaction.category %}
+  <tr>
+    <td>Kategorie</td>
+    <td>{{ transaction.category.name }}</td>
+  </tr>
+  {% endif %}
+  {% if approved_by %}
+  <tr>
+    <td>Bearbeitet von</td>
+    <td>{{ approved_by.get_full_name }}</td>
+  </tr>
+  {% endif %}
+</table>
+
+<p style="text-align: center;">
+  <a href="{{ frontend_url }}/finance/transactions" class="btn">&Ouml;ffne Transaktionen</a>
+</p>
+{% endblock %}

--- a/do-app-spec.yml
+++ b/do-app-spec.yml
@@ -36,6 +36,28 @@ services:
       - key: CELERY_BROKER_URL
         scope: RUN_TIME
         value: ${redis.INTERNAL_URL}
+      # --- E-Mail (SMTP) ---
+      - key: EMAIL_HOST
+        scope: RUN_TIME
+        value: mail.your-server.de
+      - key: EMAIL_PORT
+        scope: RUN_TIME
+        value: "587"
+      - key: EMAIL_USE_TLS
+        scope: RUN_TIME
+        value: "True"
+      - key: EMAIL_HOST_USER
+        scope: RUN_TIME
+        value: auto_benachrichtigungen@gtsplaner.app
+      - key: EMAIL_HOST_PASSWORD
+        scope: RUN_TIME
+        value: ${EMAIL_HOST_PASSWORD}
+      - key: DEFAULT_FROM_EMAIL
+        scope: RUN_TIME
+        value: "GTS Planer <auto_benachrichtigungen@gtsplaner.app>"
+      - key: FRONTEND_URL
+        scope: RUN_TIME
+        value: https://www.gtsplaner.app
       # --- CORS ---
       - key: CORS_ALLOWED_ORIGINS
         scope: RUN_TIME
@@ -88,6 +110,28 @@ workers:
       - key: CELERY_BROKER_URL
         scope: RUN_TIME
         value: ${redis.INTERNAL_URL}
+      # --- E-Mail (SMTP) – Worker braucht dieselbe Konfiguration ---
+      - key: EMAIL_HOST
+        scope: RUN_TIME
+        value: mail.your-server.de
+      - key: EMAIL_PORT
+        scope: RUN_TIME
+        value: "587"
+      - key: EMAIL_USE_TLS
+        scope: RUN_TIME
+        value: "True"
+      - key: EMAIL_HOST_USER
+        scope: RUN_TIME
+        value: auto_benachrichtigungen@gtsplaner.app
+      - key: EMAIL_HOST_PASSWORD
+        scope: RUN_TIME
+        value: ${EMAIL_HOST_PASSWORD}
+      - key: DEFAULT_FROM_EMAIL
+        scope: RUN_TIME
+        value: "GTS Planer <auto_benachrichtigungen@gtsplaner.app>"
+      - key: FRONTEND_URL
+        scope: RUN_TIME
+        value: https://www.gtsplaner.app
     instance_size_slug: basic-xxs
     instance_count: 1
     run_command: celery -A config worker -l info


### PR DESCRIPTION
## Zusammenfassung

Sprint 57 implementiert den E-Mail-Versand für Benachrichtigungen und die Passwort-Reset-Funktionalität.

### Änderungen

#### Backend (Django)
- **HTML-E-Mail-Templates**: Professionelle, responsive HTML-Templates mit Hilfswerk-Branding
  - `base.html` – Basis-Layout mit Header, Content, Footer
  - `password_reset.html` – Passwort-Reset mit Button und Fallback-Link
  - `task_assigned.html` – Aufgabenzuweisung mit Details-Tabelle
  - `task_status_changed.html` – Statusänderung mit alter/neuer Status
  - `transaction_status.html` – Transaktionsstatus (genehmigt/abgelehnt)
- **Neue Celery-Tasks**: `send_task_assigned_email`, `send_task_status_changed_email`
- **TaskViewSet erweitert**: E-Mail + In-App-Benachrichtigung bei Zuweisung und Statusänderung
- **Password-Reset**: Nutzt jetzt HTML-Template mit Plain-Text-Fallback
- **Helper-Funktionen**: `_render_email()` und `_get_frontend_url()` für konsistente E-Mail-Generierung

#### DevOps
- **do-app-spec.yml**: E-Mail-SMTP-Variablen und FRONTEND_URL für Backend + Celery-Worker
- **.env.example**: Vollständige E-Mail-Konfiguration dokumentiert

### Issues
Closes #310, #312, #315

### Testplan
- [ ] Passwort-Reset E-Mail wird gesendet
- [ ] Aufgabenzuweisung löst E-Mail aus
- [ ] Statusänderung löst E-Mail aus
- [ ] HTML-Templates werden korrekt gerendert
- [ ] Fallback auf Plain-Text funktioniert