### PR TITLE
Sprint 59: Datenkonsistenz je Benutzergruppe

### DIFF
--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -13,7 +13,13 @@ from rest_framework.response import Response
 
 from core.mixins import TenantViewSetMixin
 from core.mixins_export import ExportMixin
-from core.permissions import IsEducator, require_permission
+from core.permissions import (
+    GROUP_HIERARCHY,
+    GROUP_LOCATION_MANAGER,
+    IsEducator,
+    get_user_hierarchy_level,
+    require_permission,
+)
 
 from .models import Event, EventParticipant
 from .serializers import (
@@ -91,7 +97,14 @@ class EventViewSet(ExportMixin, TenantViewSetMixin, viewsets.ModelViewSet):
                 distinct=True,
             ),
         )
-        return qs
+        user = self.request.user
+        level = get_user_hierarchy_level(user)
+        if level >= GROUP_HIERARCHY[GROUP_LOCATION_MANAGER]:
+            return qs
+        # Educator: nur Veranstaltungen eigener Gruppen
+        return qs.filter(
+            Q(groups__members__user=user) | Q(groups__leader=user)
+        ).distinct()
 
     def perform_create(self, serializer):
         serializer.save(

--- a/backend/groups/views_attendance.py
+++ b/backend/groups/views_attendance.py
@@ -22,7 +22,12 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from core.mixins import TenantViewSetMixin
-from core.permissions import IsEducator
+from core.permissions import (
+    GROUP_HIERARCHY,
+    GROUP_LOCATION_MANAGER,
+    IsEducator,
+    get_user_hierarchy_level,
+)
 from groups.models import Group, Student
 from groups.models_attendance import Attendance
 from groups.models_protocol import DailyProtocol
@@ -101,9 +106,17 @@ class AttendanceViewSet(TenantViewSetMixin, viewsets.ModelViewSet):
         if getattr(self, "swagger_fake_view", False):
             return Attendance.objects.none()
         qs = super().get_queryset()
-        return qs.filter(is_deleted=False).select_related(
+        qs = qs.filter(is_deleted=False).select_related(
             "student", "group", "recorded_by"
         )
+        user = self.request.user
+        level = get_user_hierarchy_level(user)
+        if level >= GROUP_HIERARCHY[GROUP_LOCATION_MANAGER]:
+            return qs
+        # Educator: nur Anwesenheit eigener Gruppen
+        return qs.filter(
+            Q(group__members__user=user) | Q(group__leader=user)
+        ).distinct()
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/backend/groups/views_protocol.py
+++ b/backend/groups/views_protocol.py
@@ -2,12 +2,18 @@
 import logging
 
 import django_filters
+from django.db.models import Q
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from core.mixins import TenantViewSetMixin
 from core.mixins_export import ExportMixin
+from core.permissions import (
+    GROUP_HIERARCHY,
+    GROUP_LOCATION_MANAGER,
+    get_user_hierarchy_level,
+)
 from groups.models import Group, Student
 from groups.models_protocol import DailyProtocol
 from groups.models_transfer import GroupTransfer
@@ -74,6 +80,20 @@ class DailyProtocolViewSet(
         "school_year",
     )
     filterset_class = DailyProtocolFilter
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return DailyProtocol.objects.none()
+        qs = super().get_queryset()
+        user = self.request.user
+        level = get_user_hierarchy_level(user)
+        if level >= GROUP_HIERARCHY[GROUP_LOCATION_MANAGER]:
+            return qs
+        # Educator: nur Protokolle eigener Gruppen
+        return qs.filter(
+            Q(group__members__user=user) | Q(group__leader=user)
+        ).distinct()
+
     search_fields = []
     ordering_fields = ["date", "arrival_time", "pickup_time", "incident_severity"]
     ordering = ["-date"]

--- a/backend/system/export_views.py
+++ b/backend/system/export_views.py
@@ -133,6 +133,10 @@ class TransactionExportView(ExportMixin, APIView):
             "category", "group", "created_by", "approved_by"
         ).filter(is_deleted=False)
 
+        # Tenant-Filter: Mandantentrennung sicherstellen
+        if not getattr(request, "is_cross_tenant", False) and hasattr(request, "tenant_ids") and request.tenant_ids:
+            queryset = queryset.filter(organization_id__in=request.tenant_ids)
+
         # Apply user location filter (non-superadmin)
         if request.user.role != "super_admin" and request.user.location:
             queryset = queryset.filter(group__location=request.user.location)
@@ -223,6 +227,10 @@ class TimeEntryExportView(ExportMixin, APIView):
         # Build queryset
         queryset = TimeEntry.objects.select_related("user", "group").filter(is_deleted=False)
 
+        # Tenant-Filter: Mandantentrennung sicherstellen
+        if not getattr(request, "is_cross_tenant", False) and hasattr(request, "tenant_ids") and request.tenant_ids:
+            queryset = queryset.filter(organization_id__in=request.tenant_ids)
+
         # Apply user location filter
         if request.user.role != "super_admin" and request.user.location:
             queryset = queryset.filter(group__location=request.user.location)
@@ -310,6 +318,10 @@ class LeaveRequestExportView(ExportMixin, APIView):
         queryset = LeaveRequest.objects.select_related(
             "user", "leave_type", "approved_by"
         ).filter(is_deleted=False)
+
+        # Tenant-Filter: Mandantentrennung sicherstellen
+        if not getattr(request, "is_cross_tenant", False) and hasattr(request, "tenant_ids") and request.tenant_ids:
+            queryset = queryset.filter(organization_id__in=request.tenant_ids)
 
         # Apply user location filter
         if request.user.role != "super_admin" and request.user.location:


### PR DESCRIPTION
## Zusammenfassung

Datenkonsistenz-Audit und Fixes für rollenbasierte Datenfilterung.

## Änderungen

### Educator-Filter (KRITISCH)
- **AttendanceViewSet** (#324): Educator sieht nur Anwesenheit eigener Gruppen
- **DailyProtocolViewSet** (#325): Educator sieht nur Protokolle eigener Gruppen
- **EventViewSet** (#326): Educator sieht nur Veranstaltungen eigener Gruppen
- **StudentContactViewSet** (#326): Bereits korrekt implementiert (kein Fix nötig)
- **TransactionViewSet** (#328): Bereits korrekt implementiert (kein Fix nötig)

### Export-Views Tenant-Filter (MITTEL)
- **TransactionExportView** (#327): tenant_ids-Filter hinzugefügt
- **TimeEntryExportView** (#327): tenant_ids-Filter hinzugefügt
- **LeaveRequestExportView** (#327): tenant_ids-Filter hinzugefügt

## Technischer Ansatz
- Einheitliches Pattern: `get_user_hierarchy_level()` + `GROUP_LOCATION_MANAGER` Check
- Educator-Filter: `Q(group__members__user=user) | Q(group__leader=user)`
- Export-Views: `organization_id__in=request.tenant_ids` mit cross-tenant Check

## Milestone
Sprint 59: Datenkonsistenz je Benutzergruppe

Closes #324, #325, #326, #327, #328