### PR TITLE
Fix: Abwesenheitskategorien-Duplikate im Dropdown (Sprint 62)

### DIFF
--- a/backend/timetracking/views.py
+++ b/backend/timetracking/views.py
@@ -138,7 +138,14 @@ class LeaveTypeViewSet(TenantViewSetMixin, viewsets.ModelViewSet):
         if getattr(self, "swagger_fake_view", False):
             return LeaveType.objects.none()
         qs = super().get_queryset()
-        return qs.all()
+
+        # Educators and LocationManagers should only see leave types
+        # for their own location to avoid duplicates across locations
+        user = self.request.user
+        if user.role in ("educator", "location_manager") and user.location_id:
+            qs = qs.filter(location_id=user.location_id)
+
+        return qs
 
     def get_permissions(self):
         if self.action in ["list", "retrieve"]:


### PR DESCRIPTION
## Änderungen

- `LeaveTypeViewSet.get_queryset()` um Location-Filter erweitert
- Educators und LocationManagers sehen jetzt nur LeaveTypes ihres eigenen Standorts
- SubAdmins und Admins sehen weiterhin alle LeaveTypes ihrer Organisation

## Ursache

Der TenantFilterBackend filtert nach `organization_id`. Da LeaveTypes pro Standort erstellt werden, sahen Educators bei Mandanten mit mehreren Standorten (z.B. Kärnten: 3 Standorte) alle Typen 3-fach.

## Getestete Szenarien

- Educator (amalia.bogdan, Kärnten): Dropdown zeigt 5 statt 15 Einträge
- LocationManager: Sieht nur eigene Standort-Typen
- SubAdmin: Sieht weiterhin alle Typen der Organisation (kein Filter)
- SuperAdmin: Sieht weiterhin alle Typen systemweit (kein Filter)

Closes #353