### PR TITLE
fix(frontend): Mobile Responsive – Viewport-Overflow und Widget-Größen

### DIFF
--- a/KNOWLEDGEBASE_v38.md
+++ b/KNOWLEDGEBASE_v38.md
@@ -1,0 +1,21 @@
+## 10. Rollen & Berechtigungen (5-stufig)
+
+| Level | Rolle | Sichtbarkeit |
+|---|---|---|
+| 1 | Educator | Eigene Gruppe |
+| 2 | LocationManager | Eigener Standort |
+| 3 | SubAdmin | Gesamter Sub-Mandant kumuliert |
+| 4 | Admin | Hauptmandant + alle Sub-Mandanten |
+| 5 | SuperAdmin | Alles (cross-tenant), filterbar nach Sub-Mandant |
+
+### 10.1 Sub-Mandanten-Admin (SubAdmin)
+
+Der SubAdmin hat dieselben Berechtigungen wie der Admin, **ohne** `manage_organizations` und `cross_tenant_access`. Er kann innerhalb seines Sub-Mandanten (z.B. Hilfswerk Kärnten) Locations erstellen, Standortleitungen und Pädagoginnen verwalten und alle Daten kumuliert einsehen.
+
+### 10.2 SuperAdmin/Admin: Organization-Filter
+
+SuperAdmins und Admins können das Dashboard und alle Listen-Ansichten (Standorte, Benutzer, etc.) nach einer einzelnen Organisation filtern. Dies geschieht über den `?organization_id=<id>` Query-Parameter in der API und ein Dropdown-Menü im Frontend.
+
+## 11. Tenant-Architektur (Refactoring geplant)
+
+Die aktuelle Tenant-Isolation basiert auf einer Middleware-Funktion (`TenantMiddleware`), die `request.tenant_ids` als Seiteneffekt setzt. Dies ist nicht ideal und wird in Sprint 56 durch eine saubere, API-basierte Lösung mit `django-filter` ersetzt (siehe Issue #302).

--- a/frontend/src/app/(dashboard)/events/page.tsx
+++ b/frontend/src/app/(dashboard)/events/page.tsx
@@ -114,7 +114,7 @@ export default function EventsPage() {
       <Card>
         <CardContent className="pt-6">
           <div className="flex flex-wrap gap-4">
-            <div className="relative flex-1 min-w-[200px]">
+            <div className="relative flex-1 min-w-0 sm:min-w-[200px]">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 placeholder="Suchen..."
@@ -133,7 +133,7 @@ export default function EventsPage() {
                 setPage(1);
               }}
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Alle Typen" />
               </SelectTrigger>
               <SelectContent>
@@ -152,7 +152,7 @@ export default function EventsPage() {
                 setPage(1);
               }}
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Alle Status" />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/app/(dashboard)/finance/accounting/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/accounting/page.tsx
@@ -85,7 +85,7 @@ export default function AccountingPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Buchhaltung</h1>
           <p className="text-sm text-muted-foreground">
@@ -100,7 +100,7 @@ export default function AccountingPage() {
         <CardContent className="pt-6">
           <div className="flex flex-wrap gap-4">
             <Select value={year} onValueChange={setYear}>
-              <SelectTrigger className="w-[140px]">
+              <SelectTrigger className="w-full sm:w-[140px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -115,7 +115,7 @@ export default function AccountingPage() {
               value={groupId}
               onValueChange={(v) => setGroupId(v === "all" ? "" : v)}
             >
-              <SelectTrigger className="w-[220px]">
+              <SelectTrigger className="w-full sm:w-[220px]">
                 <SelectValue placeholder="Alle Gruppen" />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/app/(dashboard)/finance/reports/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/reports/page.tsx
@@ -239,7 +239,7 @@ export default function FinanceReportsPage() {
               value={locationId}
               onValueChange={(v) => setLocationId(v)}
             >
-              <SelectTrigger className="w-[200px]">
+              <SelectTrigger className="w-full sm:w-[200px]">
                 <SelectValue placeholder="Standort" />
               </SelectTrigger>
               <SelectContent>
@@ -257,7 +257,7 @@ export default function FinanceReportsPage() {
             value={String(year)}
             onValueChange={(v) => setYear(Number(v))}
           >
-            <SelectTrigger className="w-[120px]">
+            <SelectTrigger className="w-full sm:w-[120px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/app/(dashboard)/groups/attendance/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/attendance/page.tsx
@@ -305,7 +305,7 @@ export default function AttendancePage() {
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
-            <div className="min-w-[220px] rounded-md border bg-background px-3 py-2 text-center text-sm">
+            <div className="min-w-[140px] sm:min-w-[220px] rounded-md border bg-background px-3 py-2 text-center text-sm">
               {formatDateDisplay(selectedDate)}
             </div>
             <Button

--- a/frontend/src/app/(dashboard)/groups/contacts/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/contacts/page.tsx
@@ -218,7 +218,7 @@ export default function ContactsPage() {
                 setPage(1);
               }}
             >
-              <SelectTrigger className="w-[200px]">
+              <SelectTrigger className="w-full sm:w-[200px]">
                 <SelectValue placeholder="Beziehung" />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/app/(dashboard)/groups/daily-protocols/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/daily-protocols/page.tsx
@@ -430,7 +430,7 @@ export default function DailyProtocolsPage() {
                     value={selectedGroup}
                     onValueChange={setSelectedGroup}
                   >
-                    <SelectTrigger className="w-[220px]">
+                    <SelectTrigger className="w-full sm:w-[220px]">
                       <SelectValue placeholder="Gruppe wählen" />
                     </SelectTrigger>
                     <SelectContent>
@@ -448,7 +448,7 @@ export default function DailyProtocolsPage() {
                     type="date"
                     value={selectedDate}
                     onChange={(e) => setSelectedDate(e.target.value)}
-                    className="w-[180px]"
+                    className="w-full sm:w-[180px]"
                   />
                 </div>
                 <Button
@@ -658,7 +658,7 @@ export default function DailyProtocolsPage() {
                       setListPage(1);
                     }}
                   >
-                    <SelectTrigger className="w-[220px]">
+                    <SelectTrigger className="w-full sm:w-[220px]">
                       <SelectValue placeholder="Alle Gruppen" />
                     </SelectTrigger>
                     <SelectContent>
@@ -680,7 +680,7 @@ export default function DailyProtocolsPage() {
                       setFilterDate(e.target.value);
                       setListPage(1);
                     }}
-                    className="w-[180px]"
+                    className="w-full sm:w-[180px]"
                   />
                 </div>
                 <div className="space-y-1">
@@ -692,7 +692,7 @@ export default function DailyProtocolsPage() {
                       setListPage(1);
                     }}
                   >
-                    <SelectTrigger className="w-[160px]">
+                    <SelectTrigger className="w-full sm:w-[160px]">
                       <SelectValue placeholder="Alle" />
                     </SelectTrigger>
                     <SelectContent>

--- a/frontend/src/app/(dashboard)/groups/school-years/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/school-years/page.tsx
@@ -208,7 +208,7 @@ export default function SchoolYearsPage() {
       <Breadcrumbs />
 
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Schuljahre</h1>
           <p className="text-muted-foreground">

--- a/frontend/src/app/(dashboard)/groups/transfers/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/transfers/page.tsx
@@ -242,7 +242,7 @@ export default function TransfersPage() {
                 setPage(1);
               }}
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -33,12 +33,12 @@ export default function DashboardLayout({
             </aside>
 
             {/* Main Content */}
-            <div className="flex flex-1 flex-col">
+            <div className="flex min-w-0 flex-1 flex-col">
               <Header
                 sidebarCollapsed={sidebarCollapsed}
                 onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
               />
-              <main className="flex-1 p-4 sm:p-6">
+              <main className="flex-1 overflow-x-hidden p-4 sm:p-6">
                 <RouteGuard>{children}</RouteGuard>
               </main>
             </div>

--- a/frontend/src/app/(dashboard)/page.tsx
+++ b/frontend/src/app/(dashboard)/page.tsx
@@ -1366,7 +1366,7 @@ function OrganizationFilter({
       value={value ? String(value) : "all"}
       onValueChange={(v) => onChange(v === "all" ? undefined : Number(v))}
     >
-      <SelectTrigger className="w-[280px]">
+      <SelectTrigger className="w-full sm:w-[280px]">
         <SelectValue placeholder="Alle Organisationen" />
       </SelectTrigger>
       <SelectContent>

--- a/frontend/src/app/(dashboard)/tasks/page.tsx
+++ b/frontend/src/app/(dashboard)/tasks/page.tsx
@@ -207,7 +207,7 @@ function KanbanColumn({
   canManage: boolean;
 }) {
   return (
-    <div className={`flex-1 min-w-[280px] border-t-2 ${color} rounded-lg bg-muted/30 p-3`}>
+    <div className={`flex-1 min-w-[240px] sm:min-w-[280px] border-t-2 ${color} rounded-lg bg-muted/30 p-3`}>
       <div className="flex items-center gap-2 mb-4">
         {icon}
         <h3 className="font-semibold text-sm">{title}</h3>
@@ -611,14 +611,14 @@ export default function TasksPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Aufgaben</h1>
           <p className="text-muted-foreground">
             Aufgaben verwalten und im Kanban-Board organisieren
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* View Toggle */}
           <div className="flex border rounded-md">
             <Button
@@ -673,17 +673,17 @@ export default function TasksPage() {
       )}
 
       {/* Filters */}
-      <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-center gap-4">
         {view === "list" && (
           <Input
             placeholder="Aufgaben suchen..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="max-w-xs"
+            className="w-full sm:max-w-xs"
           />
         )}
         <Select value={filterPriority || "__all__"} onValueChange={(v) => setFilterPriority(v === "__all__" ? "" : v)}>
-          <SelectTrigger className="w-[160px]">
+          <SelectTrigger className="w-full sm:w-[160px]">
             <SelectValue placeholder="Alle Prioritäten" />
           </SelectTrigger>
           <SelectContent>
@@ -694,7 +694,7 @@ export default function TasksPage() {
           </SelectContent>
         </Select>
         <Select value={filterLocation || "__all__"} onValueChange={(v) => setFilterLocation(v === "__all__" ? "" : v)}>
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger className="w-full sm:w-[200px]">
             <SelectValue placeholder="Alle Standorte" />
           </SelectTrigger>
           <SelectContent>
@@ -712,7 +712,7 @@ export default function TasksPage() {
 
       {/* Board View */}
       {view === "board" && (
-        <div className="flex gap-6 overflow-x-auto pb-4">
+        <div className="flex gap-3 sm:gap-6 overflow-x-auto pb-4">
           <KanbanColumn
             title="Offen"
             icon={<AlertCircle className="h-5 w-5 text-blue-400" />}

--- a/frontend/src/app/(dashboard)/weeklyplans/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/weeklyplans/[id]/page.tsx
@@ -409,7 +409,7 @@ export default function WeeklyPlanDetailPage() {
           {isEditing ? (
             <>
               <Select value={editStatus} onValueChange={setEditStatus}>
-                <SelectTrigger className="w-[160px]">
+                <SelectTrigger className="w-full sm:w-[160px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>


### PR DESCRIPTION
## Zusammenfassung

Behebt #355 – Mobile Darstellung ist am Smartphone nicht in jeder View dem Viewport entsprechend optimiert.

## Änderungen (12 Dateien)

### Globale Fixes
- **layout.tsx**: `min-w-0` auf flex-1 Container + `overflow-x-hidden` auf main → verhindert horizontalen Overflow systemweit

### SelectTrigger/Input responsive
Alle festen Breiten (`w-[Npx]`) auf Formularelemente mit `w-full sm:w-[Npx]` versehen:
- Dashboard OrgFilter (w-[280px])
- Finance Reports (w-[200px], w-[120px])
- Finance Accounting (w-[140px], w-[220px])
- Groups Contacts, Transfers, Daily-Protocols
- Events, Tasks, Weeklyplans

### Layout-Fixes
- Tasks Header: `flex-col gap-4 sm:flex-row sm:items-center sm:justify-between`
- Finance Accounting Header: dto.
- School-Years Header: dto.
- Tasks Filter: `flex-wrap` hinzugefügt
- Kanban-Board: `gap-3 sm:gap-6`, Spalten `min-w-[240px] sm:min-w-[280px]`
- Attendance Datepicker: `min-w-[140px] sm:min-w-[220px]`
- Events Search: `min-w-0 sm:min-w-[200px]`

## Test-Hinweise

Auf folgenden Viewports testen:
- iPhone SE (375px)
- iPhone 14 (390px)
- Samsung Galaxy (360px)
- iPad Mini (768px)