### PR TITLE
fix(frontend): Select onValueChange String-to-Number Konvertierung

### DIFF
--- a/frontend/src/components/forms/group-form.tsx
+++ b/frontend/src/components/forms/group-form.tsx
@@ -170,7 +170,7 @@ export function GroupForm({
                 <FormItem>
                   <FormLabel>Schuljahr</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
+                    onValueChange={(value) => field.onChange(Number(value))}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>
@@ -199,7 +199,7 @@ export function GroupForm({
                   <FormItem>
                     <FormLabel>Gruppenleitung (optional)</FormLabel>
                     <Select
-                      onValueChange={field.onChange}
+                      onValueChange={(value) => field.onChange(Number(value))}
                       defaultValue={
                         field.value ? String(field.value) : undefined
                       }

--- a/frontend/src/components/forms/leave-request-form.tsx
+++ b/frontend/src/components/forms/leave-request-form.tsx
@@ -136,7 +136,7 @@ export function LeaveRequestForm({
                 <FormItem>
                   <FormLabel>Abwesenheitstyp</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
+                    onValueChange={(value) => field.onChange(Number(value))}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>

--- a/frontend/src/components/forms/student-form.tsx
+++ b/frontend/src/components/forms/student-form.tsx
@@ -192,7 +192,7 @@ export function StudentForm({
                 <FormItem>
                   <FormLabel>Gruppe</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
+                    onValueChange={(value) => field.onChange(Number(value))}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>

--- a/frontend/src/components/forms/time-entry-form.tsx
+++ b/frontend/src/components/forms/time-entry-form.tsx
@@ -129,7 +129,7 @@ export function TimeEntryForm({
                 <FormItem>
                   <FormLabel>Gruppe</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
+                    onValueChange={(value) => field.onChange(Number(value))}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>
@@ -210,7 +210,13 @@ export function TimeEntryForm({
                   <FormItem>
                     <FormLabel>Pause (Min.)</FormLabel>
                     <FormControl>
-                      <Input type="number" min="0" step="5" {...field} />
+                      <Input
+                        type="number"
+                        min="0"
+                        step="5"
+                        {...field}
+                        onChange={(e) => field.onChange(Number(e.target.value) || 0)}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/frontend/src/components/forms/transaction-form.tsx
+++ b/frontend/src/components/forms/transaction-form.tsx
@@ -189,7 +189,7 @@ export function TransactionForm({
                   <FormItem>
                     <FormLabel>Gruppe</FormLabel>
                     <Select
-                      onValueChange={field.onChange}
+                      onValueChange={(value) => field.onChange(Number(value))}
                       defaultValue={field.value ? String(field.value) : undefined}
                     >
                       <FormControl>
@@ -217,7 +217,7 @@ export function TransactionForm({
                   <FormItem>
                     <FormLabel>Kategorie</FormLabel>
                     <Select
-                      onValueChange={field.onChange}
+                      onValueChange={(value) => field.onChange(Number(value))}
                       defaultValue={
                         field.value ? String(field.value) : undefined
                       }


### PR DESCRIPTION
Behebt #357 – Radix UI Select gibt Werte als String zurueck, Zod erwartet Number.

## Aenderungen (5 Dateien)

Alle Select-Felder die z.number() im Schema erwarten mit Number()-Konvertierung versehen:

- time-entry-form.tsx: group + break_minutes
- transaction-form.tsx: group + category
- leave-request-form.tsx: leave_type
- group-form.tsx: school_year + group_leader
- student-form.tsx: group

Nicht betroffen (String-Enums bleiben unveraendert):
- transaction_type, category_type, data_consent_status, role