### PR TITLE
fix(build): pnpm onlyBuiltDependencies fuer sharp und unrs-resolver

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,5 +72,8 @@
     "eslint-config-next": "^16.1.6",
     "jsdom": "^29.0.1",
     "vitest": "^4.1.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp", "unrs-resolver"]
   }
 }


### PR DESCRIPTION
## Problem

Build schlaegt auf DigitalOcean App Platform fehl:

```
ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: sharp@0.34.5, unrs-resolver@1.11.1
Run pnpm approve-builds to pick which dependencies should be allowed to run scripts.
```

## Ursache

Seit pnpm v9+ werden Build-Scripts von Dependencies standardmaessig blockiert. sharp (Next.js Bildoptimierung) und unrs-resolver benoetigen native Build-Steps.

## Fix

package.json um pnpm.onlyBuiltDependencies erweitert:

```json
"pnpm": {
  "onlyBuiltDependencies": ["sharp", "unrs-resolver"]
}
```