### PR TITLE
fix(build): pnpm 10.11.0 pinnen + corepack prepare fuer stabilen Build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@
 FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable pnpm && pnpm install --frozen-lockfile
+RUN corepack enable && corepack prepare --activate && pnpm install --frozen-lockfile
 
 # --- Stage 2: Build ---
 FROM node:22-alpine AS builder
@@ -17,7 +17,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 # Produktions-API-URL wird zur Build-Zeit eingebettet
 ENV NEXT_PUBLIC_API_URL=https://api.gtsplaner.app/api/v1
-RUN corepack enable pnpm && pnpm build
+RUN corepack enable && corepack prepare --activate && pnpm build
 
 # --- Stage 3: Production ---
 FROM node:22-alpine AS runner

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "jsdom": "^29.0.1",
     "vitest": "^4.1.1"
   },
+  "packageManager": "pnpm@10.11.0",
   "pnpm": {
     "onlyBuiltDependencies": ["sharp", "unrs-resolver"]
   }


### PR DESCRIPTION
## Problem

Build schlaegt weiterhin fehl mit:
```
ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: sharp@0.34.5, unrs-resolver@1.11.1
```

## Ursache

corepack ohne packageManager-Pin kann pnpm 11 verwenden, wo onlyBuiltDependencies entfernt wurde (ersetzt durch allowBuilds seit pnpm 11.0, 28. April 2026).

## Fix

1. packageManager: pnpm@10.11.0 in package.json gepinnt
2. Dockerfile: corepack prepare --activate (liest Version aus package.json)
3. onlyBuiltDependencies bleibt fuer pnpm 10.x korrekt

## Ergebnis

Stabiler Build mit deterministischer pnpm-Version.