### PR TITLE
fix: Umlaute in Seed-Daten + Mitglieder-Sichtbarkeit für Educators (#363)

### DIFF
--- a/backend/core/management/commands/create_test_users.py
+++ b/backend/core/management/commands/create_test_users.py
@@ -3,8 +3,8 @@ Management command to create a realistic multi-tenant test environment.
 
 Creates the Hilfswerk Oesterreich hierarchy:
   - Main tenant: Hilfswerk Oesterreich (Hauptstandort Wien)
-  - 9 Sub-tenants: one per Bundesland (Kaernten, Wien, NOe, Tirol, etc.)
-  - Kaernten: 3 Schulstandorte (VS Annabichl, VS Woelfnitz, VS St. Ruprecht)
+  - 9 Sub-tenants: one per Bundesland (Kärnten, Wien, NOe, Tirol, etc.)
+  - Kärnten: 3 Schulstandorte (VS Annabichl, VS Wölfnitz, VS St. Ruprecht)
   - Wien: 2 Schulstandorte (VS Donaustadt, VS Favoriten)
   - Other Bundeslaender: 1 Schulstandort each
   - Each Schulstandort has a LocationManager, an Educator, a Group, and Students
@@ -56,7 +56,7 @@ class Command(BaseCommand):
 
     BUNDESLAENDER = [
         {
-            "name": "Hilfswerk Kaernten",
+            "name": "Hilfswerk Kärnten",
             "city": "Klagenfurt",
             "postal_code": "9020",
             "street": "8.-Mai-Strasse 47",
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                         "first_name": "Amalia",
                         "last_name": "Bogdan",
                     },
-                    "group_name": "Gruene Gruppe",
+                    "group_name": "Grüne Gruppe",
                     "students": [
                         {"first_name": "Lena", "last_name": "Koller", "class": "1a"},
                         {"first_name": "Maximilian", "last_name": "Steiner", "class": "1a"},
@@ -113,10 +113,10 @@ class Command(BaseCommand):
                     ],
                 },
                 {
-                    "name": "VS Woelfnitz",
+                    "name": "VS Wölfnitz",
                     "city": "Klagenfurt",
                     "postal_code": "9020",
-                    "street": "Woelfnitzstrasse 1",
+                    "street": "Wölfnitzstraße 1",
                     "email": "vs.woelfnitz@klagenfurt.at",
                     "phone": "+43 463 281 45",
                     "manager": {
@@ -540,7 +540,7 @@ class Command(BaseCommand):
     # Username pattern: admin.<bundesland_short>@hilfswerk.at
 
     SUB_ADMIN_CONFIG = {
-        "Hilfswerk Kaernten": {
+        "Hilfswerk Kärnten": {
             "username": "admin.kaernten",
             "email": "admin.kaernten@hilfswerk.at",
             "first_name": "Karl",

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -173,7 +173,7 @@ class Organization(models.Model):
     Represents an organization in a hierarchical multi-tenant structure.
 
     Hierarchy:
-        Main tenant (e.g., Hilfswerk Kaernten) -> org_type='main'
+        Main tenant (e.g., Hilfswerk Kärnten) -> org_type='main'
           Sub tenant (e.g., VS Klagenfurt)     -> org_type='sub', parent=main
           Sub tenant (e.g., VS Villach)         -> org_type='sub', parent=main
 

--- a/backend/groups/tests/test_contacts.py
+++ b/backend/groups/tests/test_contacts.py
@@ -20,7 +20,7 @@ from groups.models_contacts import StudentContact
 @pytest.fixture
 def org(db) -> Organization:
     return Organization.objects.create(
-        name="Hilfswerk Kaernten",
+        name="Hilfswerk Kärnten",
         email="hw@test.at",
         street="Teststr 1",
         city="Klagenfurt",
@@ -55,7 +55,7 @@ def group(org: Organization, loc: Location, school_year: SchoolYear) -> Group:
         organization=org,
         location=loc,
         school_year=school_year,
-        name="Gruene Gruppe",
+        name="Grüne Gruppe",
     )
 
 

--- a/backend/groups/tests/test_transfer.py
+++ b/backend/groups/tests/test_transfer.py
@@ -23,7 +23,7 @@ from groups.models_transfer import GroupTransfer
 @pytest.fixture
 def org(db) -> Organization:
     return Organization.objects.create(
-        name="Hilfswerk Kaernten",
+        name="Hilfswerk Kärnten",
         email="hw@test.at",
         street="Teststr 1",
         city="Klagenfurt",
@@ -68,7 +68,7 @@ def group_a(org: Organization, loc: Location, school_year: SchoolYear) -> Group:
         organization=org,
         location=loc,
         school_year=school_year,
-        name="Gruene Gruppe",
+        name="Grüne Gruppe",
     )
 
 

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -210,7 +210,7 @@ class GroupViewSet(TenantViewSetMixin, viewsets.ModelViewSet):
         return GroupListSerializer
 
     def get_permissions(self):
-        if self.action in ["list", "retrieve"]:
+        if self.action in ["list", "retrieve", "list_members", "list_students"]:
             return [permissions.IsAuthenticated(), IsEducator()]
         return [
             permissions.IsAuthenticated(),


### PR DESCRIPTION
## Änderungen

### 1. Umlaute korrigiert
- `Gruene Gruppe` → `Grüne Gruppe`
- `Hilfswerk Kaernten` → `Hilfswerk Kärnten`
- `VS Woelfnitz` → `VS Wölfnitz`
- `Woelfnitzstrasse` → `Wölfnitzstraße`

### 2. Mitglieder-Sichtbarkeit für Educators
- `GroupViewSet.get_permissions()`: `list_members` und `list_students` Actions für Educators freigegeben
- Zuvor: 403 Forbidden wegen fehlender `manage_groups` Permission
- Jetzt: Educators können Mitglieder und Schüler ihrer Gruppe sehen

### Betroffene Dateien
- `backend/core/management/commands/create_test_users.py`
- `backend/core/models.py`
- `backend/groups/views.py`
- `backend/groups/tests/test_contacts.py`
- `backend/groups/tests/test_transfer.py`

### Hinweis
Nach Deployment: `python manage.py create_test_users` erneut ausführen.

Closes #363