### PR TITLE
fix: DollarSign/Wallet Icons durch Coins (Münze) ersetzen (#365)

### DIFF
--- a/frontend/src/app/(dashboard)/events/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/events/[id]/page.tsx
@@ -47,7 +47,7 @@ import {
   CheckCircle,
   XCircle,
   Clock,
-  DollarSign,
+  Coins,
   UserPlus,
   FileText,
 } from "lucide-react";
@@ -285,7 +285,7 @@ export default function EventDetailPage() {
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-3">
-                <DollarSign className="h-8 w-8 text-primary" />
+                <Coins className="h-8 w-8 text-primary" />
                 <div>
                   <p className="text-2xl font-bold">
                     {stats.total_cost ? `€${stats.total_cost}` : "–"}

--- a/frontend/src/app/(dashboard)/finance/accounting/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/accounting/page.tsx
@@ -21,11 +21,10 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Wallet,
+  Coins,
   TrendingUp,
   TrendingDown,
   ArrowRightLeft,
-  DollarSign,
 } from "lucide-react";
 import type { MonthlyFinanceSummary } from "@/types/models";
 
@@ -136,7 +135,7 @@ export default function AccountingPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <Wallet className="h-8 w-8 text-blue-500" />
+              <Coins className="h-8 w-8 text-blue-500" />
               <div>
                 <p className="text-lg font-bold">{fmt(openingBalance)}</p>
                 <p className="text-xs text-muted-foreground">Anfangsbestand</p>
@@ -182,7 +181,7 @@ export default function AccountingPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <DollarSign className="h-8 w-8 text-emerald-600" />
+              <Coins className="h-8 w-8 text-emerald-600" />
               <div>
                 <p className="text-lg font-bold">{fmt(closingBalance)}</p>
                 <p className="text-xs text-muted-foreground">Endbestand</p>

--- a/frontend/src/app/(dashboard)/finance/reports/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/reports/page.tsx
@@ -38,7 +38,7 @@ import {
   TrendingUp,
   ArrowUpRight,
   ArrowDownRight,
-  Wallet,
+  Coins,
   Loader2,
   Download,
 } from "lucide-react";
@@ -298,7 +298,7 @@ export default function FinanceReportsPage() {
         <Card>
           <CardContent className="flex items-center gap-4 p-6">
             <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
-              <Wallet className="h-5 w-5 text-blue-500" />
+              <Coins className="h-5 w-5 text-blue-500" />
             </div>
             <div>
               <p className="text-sm text-muted-foreground">Saldo</p>

--- a/frontend/src/app/(dashboard)/finance/transactions/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/transactions/page.tsx
@@ -65,7 +65,7 @@ import type { Transaction } from "@/types/models";
 import type { TransactionFormData } from "@/lib/validations";
 import {
   Plus,
-  Wallet,
+  Coins,
   MoreHorizontal,
   Check,
   X,
@@ -414,7 +414,7 @@ export default function TransactionsPage() {
         </Card>
       ) : (
         <EmptyState
-          icon={Wallet}
+          icon={Coins}
           title="Keine Transaktionen"
           description={
             debouncedSearch

--- a/frontend/src/app/(dashboard)/groups/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/[id]/page.tsx
@@ -59,7 +59,7 @@ import {
   ArrowLeft,
   Users,
   GraduationCap,
-  Wallet,
+  Coins,
   Plus,
   UserPlus,
   Trash2,
@@ -193,7 +193,7 @@ export default function GroupDetailPage({
             <CardTitle className="text-sm font-medium text-muted-foreground">
               Kontostand
             </CardTitle>
-            <Wallet className="h-4 w-4 text-muted-foreground" />
+            <Coins className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div

--- a/frontend/src/app/(dashboard)/page.tsx
+++ b/frontend/src/app/(dashboard)/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/table";
 import { formatCurrency, formatDate } from "@/lib/format";
 import {
-  Wallet,
+  Coins,
   Clock,
   Users,
   AlertCircle,
@@ -265,7 +265,7 @@ function EducatorDashboard({ stats, loading }: { stats?: DashboardStats; loading
           title="Meine Transaktionen"
           value={String(stats?.transactions_count ?? 0)}
           description="Von dir erstellt"
-          icon={Wallet}
+          icon={Coins}
           loading={loading}
           href="/finance/transactions"
         />
@@ -348,7 +348,7 @@ function EducatorDashboard({ stats, loading }: { stats?: DashboardStats; loading
             </Button>
             <Button variant="outline" className="h-auto flex-col gap-2 py-4" asChild>
               <Link href="/finance/transactions">
-                <Wallet className="h-5 w-5" />
+                <Coins className="h-5 w-5" />
                 <span className="text-xs">Transaktion erfassen</span>
               </Link>
             </Button>
@@ -415,7 +415,7 @@ function LocationManagerDashboard({ stats, loading }: { stats?: DashboardStats; 
           title="Ausstehende Transaktionen"
           value={String(stats?.pending_transactions ?? 0)}
           description="Warten auf Genehmigung"
-          icon={Wallet}
+          icon={Coins}
           loading={loading}
           href="/finance/transactions"
         />
@@ -568,7 +568,7 @@ function AdminDashboard({ stats, loading, organizationId }: { stats?: DashboardS
           title="Ausstehende Transaktionen"
           value={String(stats?.pending_transactions ?? 0)}
           description="Warten auf Genehmigung"
-          icon={Wallet}
+          icon={Coins}
           loading={loading}
           href="/finance/transactions"
         />
@@ -730,7 +730,7 @@ function SuperAdminDashboard({ stats, loading, organizationId }: { stats?: Dashb
           title="Ausstehende Transaktionen"
           value={String(stats?.pending_transactions ?? 0)}
           description="Systemweit"
-          icon={Wallet}
+          icon={Coins}
           loading={loading}
           href="/finance/transactions"
         />

--- a/frontend/src/app/(dashboard)/timetracking/approval/page.tsx
+++ b/frontend/src/app/(dashboard)/timetracking/approval/page.tsx
@@ -39,7 +39,7 @@ import {
   XCircle,
   Clock,
   CalendarOff,
-  Wallet,
+  Coins,
   Loader2,
   AlertCircle,
 } from "lucide-react";
@@ -184,7 +184,7 @@ export default function ApprovalDashboardPage() {
         <StatCard
           title="Transaktionen"
           value={txCount}
-          icon={Wallet}
+          icon={Coins}
           loading={loadingTx}
         />
       </div>
@@ -202,7 +202,7 @@ export default function ApprovalDashboardPage() {
             )}
           </TabsTrigger>
           <TabsTrigger value="transactions" className="gap-2">
-            <Wallet className="h-4 w-4" />
+            <Coins className="h-4 w-4" />
             Transaktionen
             {txCount > 0 && (
               <Badge variant="warning" className="ml-1">

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { usePermissions, type PermissionCodename } from "@/hooks/use-permissions";
 import {
   LayoutDashboard,
-  Wallet,
+  Coins,
   Receipt,
   Clock,
   CalendarOff,
@@ -81,7 +81,7 @@ const navigation: NavSection[] = [
       {
         title: "Transaktionen",
         href: "/finance/transactions",
-        icon: Wallet,
+        icon: Coins,
         // All roles can see transactions (view_own_transactions)
         permission: "view_own_transactions",
       },


### PR DESCRIPTION
Alle Finanz-Icons von DollarSign/Wallet auf Coins umgestellt.

8 Dateien, 22 Insertions, 23 Deletions.

Closes #365