### PR TITLE
fix: TransactionManagementError bei Deployment behoben

### DIFF
--- a/backend/core/management/commands/create_test_users.py
+++ b/backend/core/management/commands/create_test_users.py
@@ -758,71 +758,112 @@ class Command(BaseCommand):
 
     def _cleanup_old_data(self):
         """Remove old test data to avoid FK constraint violations."""
+        from django.db import transaction
+
         self.stdout.write("\n  [0/10] Alte Testdaten bereinigen...")
 
         # Delete StudentContacts (encrypted, FK to Student)
         from groups.models_contacts import StudentContact
-        sc_count = StudentContact.objects.count()
-        if sc_count > 0:
-            StudentContact.objects.all().delete()
-            self.stdout.write(f"        {sc_count} StudentContacts geloescht.")
-            logger.info("Cleanup: %d StudentContacts geloescht.", sc_count)
-
         try:
-            # 1. Nullify location FK on all test users
-            old_users = User.objects.filter(username__in=self.ALL_TEST_USERNAMES)
-            count = old_users.count()
-            if count > 0:
-                old_users.update(location=None)
-                self.stdout.write(f"        {count} Benutzer: location auf NULL gesetzt.")
-
-            # 2. Nullify leader FK on all groups led by test users
-            from groups.models import Group as GrpModel
-            grp_count = GrpModel.objects.filter(
-                leader__username__in=self.ALL_TEST_USERNAMES
-            ).update(leader=None)
-            if grp_count:
-                self.stdout.write(f"        {grp_count} Gruppen: leader auf NULL gesetzt.")
-
-            # 3. Nullify manager FK on all locations managed by test users
-            loc_mgr_count = Location.objects.filter(
-                manager__username__in=self.ALL_TEST_USERNAMES
-            ).update(manager=None)
-            if loc_mgr_count:
-                self.stdout.write(f"        {loc_mgr_count} Standorte: manager auf NULL gesetzt.")
-
-            # 4. Remove GroupMember entries for legacy users
-            gm_count = GroupMember.objects.filter(
-                user__username__in=["locationmanager", "educator"]
-            ).delete()[0]
-            if gm_count:
-                self.stdout.write(f"        {gm_count} GroupMember-Eintraege geloescht.")
-
-            # 5. Delete non-Hilfswerk locations (legacy)
-            old_locations = Location.objects.exclude(
-                organization__name__startswith="Hilfswerk"
-            ).exclude(name="Hauptstandort Wien")
-            loc_count = old_locations.count()
-            if loc_count > 0:
-                old_locations.delete()
-                self.stdout.write(f"        {loc_count} alte Standorte geloescht.")
-
-            # 6. Delete legacy users (old generic test accounts)
-            legacy_users = User.objects.filter(
-                username__in=["locationmanager", "educator"]
-            )
-            legacy_count = legacy_users.count()
-            if legacy_count > 0:
-                legacy_users.delete()
-                self.stdout.write(f"        {legacy_count} Legacy-Benutzer geloescht.")
-
-            if count == 0 and loc_count == 0 and legacy_count == 0:
-                self.stdout.write("        Keine alten Daten gefunden.")
-
+            with transaction.atomic():
+                sc_count = StudentContact.objects.count()
+                if sc_count > 0:
+                    StudentContact.objects.all().delete()
+                    self.stdout.write(f"        {sc_count} StudentContacts geloescht.")
+                    logger.info("Cleanup: %d StudentContacts geloescht.", sc_count)
         except Exception as e:
             self.stdout.write(
-                self.style.WARNING(f"        Cleanup-Fehler (wird fortgesetzt): {e}")
+                self.style.WARNING(f"        StudentContacts Cleanup-Fehler: {e}")
             )
+
+        # 1. Nullify location FK on all test users
+        try:
+            with transaction.atomic():
+                old_users = User.objects.filter(username__in=self.ALL_TEST_USERNAMES)
+                count = old_users.count()
+                if count > 0:
+                    old_users.update(location=None)
+                    self.stdout.write(f"        {count} Benutzer: location auf NULL gesetzt.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        User-Cleanup-Fehler: {e}")
+            )
+            count = 0
+
+        # 2. Nullify leader FK on all groups led by test users
+        try:
+            with transaction.atomic():
+                from groups.models import Group as GrpModel
+                grp_count = GrpModel.objects.filter(
+                    leader__username__in=self.ALL_TEST_USERNAMES
+                ).update(leader=None)
+                if grp_count:
+                    self.stdout.write(f"        {grp_count} Gruppen: leader auf NULL gesetzt.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        Group-Leader-Cleanup-Fehler: {e}")
+            )
+
+        # 3. Nullify manager FK on all locations managed by test users
+        try:
+            with transaction.atomic():
+                loc_mgr_count = Location.objects.filter(
+                    manager__username__in=self.ALL_TEST_USERNAMES
+                ).update(manager=None)
+                if loc_mgr_count:
+                    self.stdout.write(f"        {loc_mgr_count} Standorte: manager auf NULL gesetzt.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        Location-Manager-Cleanup-Fehler: {e}")
+            )
+
+        # 4. Remove GroupMember entries for legacy users
+        try:
+            with transaction.atomic():
+                gm_count = GroupMember.objects.filter(
+                    user__username__in=["locationmanager", "educator"]
+                ).delete()[0]
+                if gm_count:
+                    self.stdout.write(f"        {gm_count} GroupMember-Eintraege geloescht.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        GroupMember-Cleanup-Fehler: {e}")
+            )
+
+        # 5. Delete non-Hilfswerk locations (legacy)
+        loc_count = 0
+        try:
+            with transaction.atomic():
+                old_locations = Location.objects.exclude(
+                    organization__name__startswith="Hilfswerk"
+                ).exclude(name="Hauptstandort Wien")
+                loc_count = old_locations.count()
+                if loc_count > 0:
+                    old_locations.delete()
+                    self.stdout.write(f"        {loc_count} alte Standorte geloescht.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        Location-Cleanup-Fehler: {e}")
+            )
+
+        # 6. Delete legacy users (old generic test accounts)
+        legacy_count = 0
+        try:
+            with transaction.atomic():
+                legacy_users = User.objects.filter(
+                    username__in=["locationmanager", "educator"]
+                )
+                legacy_count = legacy_users.count()
+                if legacy_count > 0:
+                    legacy_users.delete()
+                    self.stdout.write(f"        {legacy_count} Legacy-Benutzer geloescht.")
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"        Legacy-User-Cleanup-Fehler: {e}")
+            )
+
+        if count == 0 and loc_count == 0 and legacy_count == 0:
+            self.stdout.write("        Keine alten Daten gefunden.")
 
     # ── Step 1: Permission Groups ─────────────────────────────────────────
 

--- a/backend/core/migrations/0012_fix_all_umlaute_and_german_months.py
+++ b/backend/core/migrations/0012_fix_all_umlaute_and_german_months.py
@@ -3,8 +3,7 @@ Data migration to fix all missing Umlaute and English month names in seeded data
 Corrects:
 - TransactionCategory names and descriptions
 - Transaction descriptions (English months → German months)
-- WeeklyPlanEntry titles
-- Event titles
+- WeeklyPlanEntry activity names
 """
 
 from django.db import migrations
@@ -77,17 +76,20 @@ def fix_transaction_descriptions(apps, schema_editor):
 
 
 def fix_weeklyplan_entries(apps, schema_editor):
-    """Fix Umlaute in WeeklyPlanEntry titles."""
+    """Fix Umlaute in WeeklyPlanEntry activity names."""
     WeeklyPlanEntry = apps.get_model("weeklyplans", "WeeklyPlanEntry")
 
+    # WeeklyPlanEntry uses 'activity' field, not 'title'
     entry_replacements = {
         "Lernfoerderung": "Lernförderung",
         "Fruehstueck": "Frühstück",
         "Yoga fuer Kinder": "Yoga für Kinder",
     }
 
-    for old_title, new_title in entry_replacements.items():
-        WeeklyPlanEntry.objects.filter(title=old_title).update(title=new_title)
+    for old_activity, new_activity in entry_replacements.items():
+        WeeklyPlanEntry.objects.filter(activity=old_activity).update(
+            activity=new_activity
+        )
 
 
 def noop(apps, schema_editor):

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -35,7 +35,7 @@ python manage.py setup_permissions --reset --migrate-users || {
 # Running it in the background ensures Gunicorn starts immediately and
 # the health check passes within the timeout window.
 echo "[4/4] Creating/updating test users (background)..."
-python manage.py create_test_users > /tmp/seed_output.log 2>&1 &
+python manage.py create_test_users --force > /tmp/seed_output.log 2>&1 &
 SEED_PID=$!
 echo "  Seed process started (PID: $SEED_PID), continuing with server start..."
 


### PR DESCRIPTION
Problem: TransactionManagementError bei jedem Deployment. Root Cause: 1) Migration 0012 referenziert WeeklyPlanEntry.title das nicht existiert (korrekt: activity). 2) startup.sh fehlt --force Flag. 3) _cleanup_old_data() hat einen einzelnen try/except ohne Savepoints. Fixes: Migration 0012 title->activity, startup.sh --force, Cleanup mit transaction.atomic() Savepoints.